### PR TITLE
Support amazoncom service principal

### DIFF
--- a/policyuniverse/arn.py
+++ b/policyuniverse/arn.py
@@ -47,7 +47,7 @@ class ARN(object):
             self._from_account_number(input)
             return
 
-        aws_service_match = re.search('^([^.]+)(.[^.]+)?\.amazonaws\.com$', input)
+        aws_service_match = re.search('^([^.]+)(.[^.]+)?\.amazon(aws)?\.com$', input)
         if aws_service_match:
             self._from_aws_service(input, aws_service_match.group(1))
             return

--- a/policyuniverse/arn.py
+++ b/policyuniverse/arn.py
@@ -47,7 +47,12 @@ class ARN(object):
             self._from_account_number(input)
             return
 
-        aws_service_match = re.search('^([^.]+)(.[^.]+)?\.amazon(aws)?\.com$', input)
+        aws_service_match = re.search('^(([^.]+)(.[^.]+)?)\.amazon(aws)?\.com$', input)
+        if aws_service_match:
+            self._from_aws_service(input, aws_service_match.group(1))
+            return
+
+        aws_service_match = re.search('^([^.]+).aws.internal$', input)
         if aws_service_match:
             self._from_aws_service(input, aws_service_match.group(1))
             return

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup
 
 setup(name='policyuniverse',
-      version='1.0.7.5',
+      version='1.0.7.6',
       description='AWS IAM Policy Utilities',
       author='Patrick Kelley',
       author_email='pkelley@netflix.com',


### PR DESCRIPTION
Add support for *.amazon.com service principals.

A few new service principals use *.amazon.com instead of *.amazonaws.com.  

Examples are:
     alexa-appkit.amazon.com
     alexa-connectedhome.amazon.com
     alexa-appkit.amazon.com

The ARN class should be able to parse these service principals.


