### PR TITLE
Added 'aws' to regex account_number group

### DIFF
--- a/policyuniverse/arn.py
+++ b/policyuniverse/arn.py
@@ -34,7 +34,7 @@ class ARN(object):
     service = False
 
     def __init__(self, input):
-        arn_match = re.search('^arn:([^:]*):([^:]*):([^:]*):(|\*|[\d]{12}|cloudfront):(.+)$', input)
+        arn_match = re.search('^arn:([^:]*):([^:]*):([^:]*):(|\*|[\d]{12}|cloudfront|aws):(.+)$', input)
         if arn_match:
             if arn_match.group(2) == "iam" and arn_match.group(5) == "root":
                 self.root = True

--- a/policyuniverse/tests/test_arn.py
+++ b/policyuniverse/tests/test_arn.py
@@ -42,7 +42,8 @@ class ARNTestCase(unittest.TestCase):
             'arn:aws:ec2:ap-northeast-1:012345678910:security-group/*',
             'arn:aws-cn:ec2:ap-northeast-1:012345678910:security-group/*',
             'arn:aws-us-gov:ec2:gov-west-1:012345678910:instance/*',
-            'arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity EXXXXXXXXXXXXX'
+            'arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity EXXXXXXXXXXXXX',
+            'arn:aws:iam::aws:policy/AlexaForBusinessDeviceSetup'
         ]
 
         # Proper ARN Tests:


### PR DESCRIPTION
Some IAM resources like Managed Policies use "aws" as the account number:

> arn:aws:iam::aws:policy/AlexaForBusinessDeviceSetup

I've added it to the regex capture group (similar to how cloudfront is whitelisted)