### PR TITLE
Fixing Issue #15. Condition blocks using ForAny/ForAll must be a list or they are invalid

### DIFF
--- a/policyuniverse/statement.py
+++ b/policyuniverse/statement.py
@@ -182,6 +182,12 @@ class Statement(object):
         for condition_operator in condition.keys():
             if any(regex.match(condition_operator) for regex in relevant_condition_operators):
                 for key, value in condition[condition_operator].items():
+
+                    # ForAllValues and ForAnyValue must be paired with a list.
+                    # Otherwise, skip over entries.
+                    if not isinstance(value, list) and condition_operator.lower().startswith('for'):
+                        continue
+
                     if key.lower() in key_mapping:
                         if isinstance(value, list):
                             for v in value:


### PR DESCRIPTION
Fixing Issue #15. Condition blocks using ForAny/ForAll must be a list or they are invalid