### PR TITLE
Update policy data

### DIFF
--- a/policyuniverse/data.json
+++ b/policyuniverse/data.json
@@ -11177,286 +11177,6 @@
     },
     "prefix": "cloudwatch"
   },
-  "CloudWatch Events": {
-    "actions": {
-      "DeleteRule": {
-        "aws_action_groups": [
-          "ReadWrite"
-        ],
-        "calculated_action_group": "Write",
-        "condition_keys": [],
-        "description": "Deletes a rule. You must remove all targets from a rule using RemoveTargets before you can delete the rule.",
-        "docs": {
-          "api_doc": "",
-          "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_DeleteRule.html"
-        }
-      },
-      "DescribeEventBus": {
-        "aws_action_groups": [
-          "ReadOnly",
-          "ReadWrite"
-        ],
-        "calculated_action_group": "Read",
-        "condition_keys": [],
-        "description": "Displays the external AWS accounts that are permitted to write events to your account using your account's event bus, and the associated policy.",
-        "docs": {
-          "api_doc": "",
-          "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_DescribeEventBus.html"
-        }
-      },
-      "DescribeRule": {
-        "aws_action_groups": [
-          "ReadOnly",
-          "ReadWrite"
-        ],
-        "calculated_action_group": "Read",
-        "condition_keys": [],
-        "description": "Describes the details of the specified rule",
-        "docs": {
-          "api_doc": "",
-          "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_DescribeRule.html"
-        }
-      },
-      "DisableRule": {
-        "aws_action_groups": [
-          "ReadWrite"
-        ],
-        "calculated_action_group": "Write",
-        "condition_keys": [],
-        "description": "Disables a rule. A disabled rule won't match any events, and won't self-trigger if it has a schedule expression.",
-        "docs": {
-          "api_doc": "",
-          "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_DisableRule.html"
-        }
-      },
-      "EnableRule": {
-        "aws_action_groups": [
-          "ReadWrite"
-        ],
-        "calculated_action_group": "Write",
-        "condition_keys": [],
-        "description": "Enables a rule. If the rule does not exist, the operation fails",
-        "docs": {
-          "api_doc": "",
-          "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_EnableRule.html"
-        }
-      },
-      "ListRuleNamesByTarget": {
-        "aws_action_groups": [
-          "ListOnly",
-          "ReadOnly",
-          "ReadWrite"
-        ],
-        "calculated_action_group": "List",
-        "condition_keys": [],
-        "description": "Lists the names of the rules that the given target is put to",
-        "docs": {
-          "api_doc": "",
-          "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_ListRuleNamesByTarget.html"
-        }
-      },
-      "ListRules": {
-        "aws_action_groups": [
-          "ListOnly",
-          "ReadOnly",
-          "ReadWrite"
-        ],
-        "calculated_action_group": "List",
-        "condition_keys": [],
-        "description": "Lists the Amazon CloudWatch Events rules in your account",
-        "docs": {
-          "api_doc": "",
-          "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_ListRules.html"
-        }
-      },
-      "ListTagsForResource": {
-        "aws_action_groups": [
-          "ListOnly",
-          "ReadOnly",
-          "ReadWrite"
-        ],
-        "calculated_action_group": "List",
-        "condition_keys": [],
-        "description": "This action lists tags for an Amazon CloudWatch Events resource.",
-        "docs": {
-          "api_doc": "",
-          "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_ListTagsForResource.html"
-        }
-      },
-      "ListTargetsByRule": {
-        "aws_action_groups": [
-          "ListOnly",
-          "ReadOnly",
-          "ReadWrite"
-        ],
-        "calculated_action_group": "List",
-        "condition_keys": [],
-        "description": "Lists of targets assigned to the rule",
-        "docs": {
-          "api_doc": "",
-          "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_ListTargetsByRule.html"
-        }
-      },
-      "PutEvents": {
-        "aws_action_groups": [
-          "ReadWrite"
-        ],
-        "calculated_action_group": "Write",
-        "condition_keys": [],
-        "description": "Sends custom events to Amazon CloudWatch Events so that they can be matched to rules",
-        "docs": {
-          "api_doc": "",
-          "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_PutEvents.html"
-        }
-      },
-      "PutPermission": {
-        "aws_action_groups": [
-          "ReadWrite"
-        ],
-        "calculated_action_group": "Write",
-        "condition_keys": [],
-        "description": "Running PutPermission permits the specified AWS account to put events to your account's default event bus.",
-        "docs": {
-          "api_doc": "",
-          "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_PutPermission.html"
-        }
-      },
-      "PutRule": {
-        "aws_action_groups": [
-          "ReadWrite",
-          "Tagging"
-        ],
-        "calculated_action_group": "Tagging",
-        "condition_keys": [
-          "aws:RequestTag/${TagKey}",
-          "aws:TagKeys",
-          "events:detail-type",
-          "events:detail.eventTypeCode",
-          "events:detail.service",
-          "events:detail.userIdentity.principalId",
-          "events:source"
-        ],
-        "description": "Creates or updates a rule. Rules are enabled by default, or based on value of the State parameter",
-        "docs": {
-          "api_doc": "",
-          "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_PutRule.html"
-        }
-      },
-      "PutTargets": {
-        "aws_action_groups": [
-          "ReadWrite"
-        ],
-        "calculated_action_group": "Write",
-        "condition_keys": [
-          "events:TargetArn"
-        ],
-        "description": "Adds target(s) to a rule. Targets are the resources that can be invoked when a rule is triggered",
-        "docs": {
-          "api_doc": "",
-          "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_PutTargets.html"
-        }
-      },
-      "RemovePermission": {
-        "aws_action_groups": [
-          "ReadWrite"
-        ],
-        "calculated_action_group": "Write",
-        "condition_keys": [],
-        "description": "Revokes the permission of another AWS account to be able to put events to your default event bus.",
-        "docs": {
-          "api_doc": "",
-          "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_RemovePermission.html"
-        }
-      },
-      "RemoveTargets": {
-        "aws_action_groups": [
-          "ReadWrite"
-        ],
-        "calculated_action_group": "Write",
-        "condition_keys": [],
-        "description": "Removes target(s) from a rule so that when the rule is triggered, those targets will no longer be invoked",
-        "docs": {
-          "api_doc": "",
-          "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_RemoveTargets.html"
-        }
-      },
-      "TagResource": {
-        "aws_action_groups": [
-          "ReadWrite",
-          "Tagging"
-        ],
-        "calculated_action_group": "Tagging",
-        "condition_keys": [
-          "aws:RequestTag/${TagKey}",
-          "aws:TagKeys"
-        ],
-        "description": "This action tags an Amazon CloudWatch Events resource.",
-        "docs": {
-          "api_doc": "",
-          "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_TagResource.html"
-        }
-      },
-      "TestEventPattern": {
-        "aws_action_groups": [
-          "ReadOnly",
-          "ReadWrite"
-        ],
-        "calculated_action_group": "Read",
-        "condition_keys": [],
-        "description": "Tests whether an event pattern matches the provided event",
-        "docs": {
-          "api_doc": "",
-          "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_TestEventPattern.html"
-        }
-      },
-      "UntagResource": {
-        "aws_action_groups": [
-          "ReadWrite",
-          "Tagging"
-        ],
-        "calculated_action_group": "Tagging",
-        "condition_keys": [
-          "aws:TagKeys"
-        ],
-        "description": "This action removes a tag from an Amazon CloudWatch Events resource.",
-        "docs": {
-          "api_doc": "",
-          "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_UntagResource.html"
-        }
-      }
-    },
-    "arn_format": "arn:aws:<serviceName>:<region>:<account>:<resourceType>/<resourceName>",
-    "arn_regex": "^arn:aws:events:.+",
-    "description": "Amazon CloudWatch Events",
-    "docs": {
-      "actions_doc_root": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/",
-      "api_detail_root": "",
-      "api_doc_root": "",
-      "api_reference_doc_page": "https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/",
-      "authz_doc_page": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/auth-and-access-control-cwe.html",
-      "concepts_doc_root": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/",
-      "context_keys_doc_root": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/"
-    },
-    "prefix": "events"
-  },
   "CloudWatch Logs": {
     "actions": {
       "AssociateKmsKey": {
@@ -34147,6 +33867,465 @@
     },
     "prefix": "es"
   },
+  "EventBridge": {
+    "actions": {
+      "ActivateEventSource": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Activates a partner event source that has been deactivated. Once activated, your matching event bus will start receiving events from the event source.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_ActivateEventSource.html"
+        }
+      },
+      "CreateEventBus": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Creates a new event bus within your account. This can be a custom event bus which you can use to receive events from your own custom applications and services, or it can be a partner event bus which can be matched to a partner event source.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_CreateEventBus.html"
+        }
+      },
+      "CreatePartnerEventSource": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Called by an AWS partner to create a partner event source.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_CreatePartnerEventSource.html"
+        }
+      },
+      "DeactivateEventSource": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Called by an AWS partner to create a partner event source.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DeactivateEventSource.html"
+        }
+      },
+      "DeleteEventBus": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Deletes the specified custom event bus or partner event bus. All rules associated with this event bus are also deleted. You can't delete your account's default event bus.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DeletePartnerEventSource"
+        }
+      },
+      "DeletePartnerEventSource": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Called by an AWS partner to delete a partner event source.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DeletePartnerEventSource"
+        }
+      },
+      "DeleteRule": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Deletes a rule. You must remove all targets from a rule using RemoveTargets before you can delete the rule.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DeleteRule.html"
+        }
+      },
+      "DescribeEventBus": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Displays the external AWS accounts that are permitted to write events to your account using your account's event bus, and the associated policy.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DescribeEventBus.html"
+        }
+      },
+      "DescribeEventSource": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Describes the details of the specified partner event source that is shared with your account.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DescribeEventSource.html"
+        }
+      },
+      "DescribePartnerEventSource": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Called by an AWS partner describe the details of the specified partner event source that they have created.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DescribePartnerEventSource.html"
+        }
+      },
+      "DescribeRule": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Describes the details of the specified rule.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DescribeRule.html"
+        }
+      },
+      "DisableRule": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Disables a rule. A disabled rule won't match any events, and won't self-trigger if it has a schedule expression.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DisableRule.html"
+        }
+      },
+      "EnableRule": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Enables a rule. If the rule does not exist, the operation fails.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_EnableRule.html"
+        }
+      },
+      "ListEventBuses": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Lists all the event buses in your account, including the default event bus, custom event buses, and partner event buses.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_ListEventBuses.html"
+        }
+      },
+      "ListEventSources": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Lists the event sources shared with this account.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_ListEventSources.html"
+        }
+      },
+      "ListPartnerEventSourceAccounts": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Called by an AWS partner to display the AWS account ID that the specified partner event source is associated with.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_ListPartnerEventSourceAccounts.html"
+        }
+      },
+      "ListPartnerEventSources": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Called by an AWS partner to list all the partner event sources that they have created.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_ListPartnerEventSources.html"
+        }
+      },
+      "ListRuleNamesByTarget": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Lists the names of the rules that the given target is put to.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_ListRuleNamesByTarget.html"
+        }
+      },
+      "ListRules": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Lists the Amazon EventBridge rules in your account.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_ListRules.html"
+        }
+      },
+      "ListTagsForResource": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "This action lists tags for an Amazon EventBridge resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_ListTagsForResource.html"
+        }
+      },
+      "ListTargetsByRule": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Lists of targets assigned to the rule.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_ListTargetsByRule.html"
+        }
+      },
+      "PutEvents": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Sends custom events to Amazon EventBridge so that they can be matched to rules.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutEvents.html"
+        }
+      },
+      "PutPartnerEvents": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Sends custom events to Amazon EventBridge so that they can be matched to rules.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutEvents.html"
+        }
+      },
+      "PutPermission": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Running PutPermission permits the specified AWS account to put events to your account's default event bus.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutPermission.html"
+        }
+      },
+      "PutRule": {
+        "aws_action_groups": [
+          "ReadWrite",
+          "Tagging"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys",
+          "events:detail-type",
+          "events:detail.eventTypeCode",
+          "events:detail.service",
+          "events:detail.userIdentity.principalId",
+          "events:source"
+        ],
+        "description": "Creates or updates a rule. Rules are enabled by default, or based on value of the State parameter.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutRule.html"
+        }
+      },
+      "PutTargets": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "events:TargetArn"
+        ],
+        "description": "Adds target(s) to a rule. Targets are the resources that can be invoked when a rule is triggered.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutTargets.html"
+        }
+      },
+      "RemovePermission": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Revokes the permission of another AWS account to be able to put events to your default event bus.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_RemovePermission.html"
+        }
+      },
+      "RemoveTargets": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Removes target(s) from a rule so that when the rule is triggered, those targets will no longer be invoked.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_RemoveTargets.html"
+        }
+      },
+      "TagResource": {
+        "aws_action_groups": [
+          "ReadWrite",
+          "Tagging"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
+        "description": "This action tags an Amazon EventBridge resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_TagResource.html"
+        }
+      },
+      "TestEventPattern": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Tests whether an event pattern matches the provided event.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_TestEventPattern.html"
+        }
+      },
+      "UntagResource": {
+        "aws_action_groups": [
+          "ReadWrite",
+          "Tagging"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:TagKeys"
+        ],
+        "description": "This action removes a tag from an Amazon EventBridge resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_UntagResource.html"
+        }
+      }
+    },
+    "arn_format": "arn:aws:<serviceName>:<region>:<account>:<resourceType>/<resourceName>",
+    "arn_regex": "^arn:aws:events:.+",
+    "description": "Amazon EventBridge",
+    "docs": {
+      "actions_doc_root": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/",
+      "api_detail_root": "",
+      "api_doc_root": "",
+      "api_reference_doc_page": "https://docs.aws.amazon.com/eventbridge/latest/APIReference/",
+      "authz_doc_page": "https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html",
+      "concepts_doc_root": "https://docs.aws.amazon.com/eventbridge/latest/userguide/",
+      "context_keys_doc_root": "https://docs.aws.amazon.com/eventbridge/latest/userguide/"
+    },
+    "prefix": "events"
+  },
   "ExecuteAPI": {
     "actions": {
       "InvalidateCache": {
@@ -37765,7 +37944,7 @@
           "aws:RequestTag/${TagKey}",
           "aws:TagKeys"
         ],
-        "description": "Grants permission to create  a connector definition.",
+        "description": "Grants permission to create a connector definition.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -39114,7 +39293,7 @@
     },
     "arn_format": "arn:aws:greengrass:<region>:<account_ID>:/greengrass/<type>/<Id>",
     "arn_regex": "^arn:aws:greengrass:.+:[0-9]+:.+",
-    "description": "AWS Greengrass",
+    "description": "AWS IoT Greengrass",
     "docs": {
       "actions_doc_root": "https://docs.aws.amazon.com/greengrass/latest/apireference/",
       "api_detail_root": "",

--- a/policyuniverse/data.json
+++ b/policyuniverse/data.json
@@ -6,7 +6,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Used to delete resources",
         "docs": {
           "api_doc": "",
@@ -33,7 +36,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Used to update resources",
         "docs": {
           "api_doc": "",
@@ -46,7 +52,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Used to create child resources",
         "docs": {
           "api_doc": "",
@@ -59,7 +68,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Used to update resources (and, although not recommended, can be used to create child resources)",
         "docs": {
           "api_doc": "",
@@ -494,7 +506,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/a4b/latest/APIReference/API_DisassociateContactFromAddressBook"
+          "doc_page_rel": "https://docs.aws.amazon.com/a4b/latest/APIReference/API_DisassociateContactFromAddressBook.html"
         }
       },
       "DisassociateDeviceFromRoom": {
@@ -1091,7 +1103,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Updates the configuration of the report delivery schedule with the specified schedule ARN. ",
+        "description": "Updates the configuration of the report delivery schedule with the specified schedule ARN.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -1198,7 +1210,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a new Amplify App.",
         "docs": {
           "api_doc": "",
@@ -1211,8 +1226,24 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a new Branch for an Amplify App.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/amplify/latest/userguide/welcome.html"
+        }
+      },
+      "CreateDeployment": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Create a deployment for manual deploy apps. (Apps are not connected to repository)",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -1224,8 +1255,24 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Create a new DomainAssociation on an App",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/amplify/latest/userguide/welcome.html"
+        }
+      },
+      "CreateWebHook": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Create a new webhook on an App.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -1284,6 +1331,19 @@
           "doc_page_rel": "https://docs.aws.amazon.com/amplify/latest/userguide/welcome.html"
         }
       },
+      "DeleteWebHook": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Delete a webhook by id.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/amplify/latest/userguide/welcome.html"
+        }
+      },
       "GetApp": {
         "aws_action_groups": [
           "ReadOnly",
@@ -1334,6 +1394,20 @@
         "calculated_action_group": "Read",
         "condition_keys": [],
         "description": "Get a job for a branch, part of an Amplify App.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/amplify/latest/userguide/welcome.html"
+        }
+      },
+      "GetWebHook": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Retrieves webhook info that corresponds to a webhookId.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -1400,6 +1474,34 @@
           "doc_page_rel": "https://docs.aws.amazon.com/amplify/latest/userguide/welcome.html"
         }
       },
+      "ListWebHooks": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "List webhooks on an App.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/amplify/latest/userguide/welcome.html"
+        }
+      },
+      "StartDeployment": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Start a deployment for manual deploy apps. (Apps are not connected to repository)",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/amplify/latest/userguide/welcome.html"
+        }
+      },
       "StartJob": {
         "aws_action_groups": [
           "ReadWrite"
@@ -1420,6 +1522,39 @@
         "calculated_action_group": "Write",
         "condition_keys": [],
         "description": "Stop a job that is in progress, for an Amplify branch, part of Amplify App.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/amplify/latest/userguide/welcome.html"
+        }
+      },
+      "TagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:TagKeys",
+          "aws:RequestTag/${TagKey}"
+        ],
+        "description": "This action tags an AWS Amplify Console resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/amplify/latest/userguide/welcome.html"
+        }
+      },
+      "UntagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:TagKeys"
+        ],
+        "description": "This action removes a tag from an AWS Amplify Console resource.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -1459,6 +1594,19 @@
         "calculated_action_group": "Write",
         "condition_keys": [],
         "description": "Update a DomainAssociation on an App.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/amplify/latest/userguide/welcome.html"
+        }
+      },
+      "UpdateWebHook": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Update a webhook.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -1787,6 +1935,20 @@
           "doc_page_rel": "https://docs.aws.amazon.com/app-mesh/latest/APIReference/API_ListVirtualServices.html"
         }
       },
+      "StreamAggregatedResources": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Allows an Envoy Proxy to receive streamed resources for a VirtualNode.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/app-mesh/latest/userguide/envoy.html"
+        }
+      },
       "TagResource": {
         "aws_action_groups": [
           "ReadWrite"
@@ -1966,7 +2128,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Grants permission to create a Directory Config object in AppStream 2.0. This object includes the information required to join streaming instances to an Active Directory domain",
+        "description": "Grants permission to create a Directory Config object in AppStream 2.0. This object includes the configuration information required to join fleets and image builders to Microsoft Active Directory domains",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -2051,6 +2213,19 @@
           "doc_page_rel": "https://docs.aws.amazon.com/appstream2/latest/APIReference/API_CreateStreamingURL.html"
         }
       },
+      "CreateUsageReportSubscription": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to create a usage report subscription. Usage reports are generated daily",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/appstream2/latest/APIReference/API_CreateUsageReportSubscription.html"
+        }
+      },
       "CreateUser": {
         "aws_action_groups": [
           "ReadWrite"
@@ -2070,7 +2245,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Grants permission to delete the specified Directory Config object from AppStream 2.0. This object includes the information required to join streaming instances to an Active Directory domain",
+        "description": "Grants permission to delete the specified Directory Config object from AppStream 2.0. This object includes the configuration information required to join fleets and image builders to Microsoft Active Directory domains",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -2152,6 +2327,19 @@
           "doc_page_rel": "https://docs.aws.amazon.com/appstream2/latest/APIReference/API_DeleteStack.html"
         }
       },
+      "DeleteUsageReportSubscription": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to disable usage report generation",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/appstream2/latest/APIReference/API_DeleteUsageReportSubscription.html"
+        }
+      },
       "DeleteUser": {
         "aws_action_groups": [
           "ReadWrite"
@@ -2172,7 +2360,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Grants permission to retrieve a list that describes one or more specified Directory Config objects for AppStream 2.0, if the names for these objects are provided. Otherwise, all Directory Config objects in the account are described. This object includes the information required to join streaming instances to an Active Directory domain",
+        "description": "Grants permission to retrieve a list that describes one or more specified Directory Config objects for AppStream 2.0, if the names for these objects are provided. Otherwise, all Directory Config objects in the account are described. This object includes the configuration information required to join fleets and image builders to Microsoft Active Directory domains",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -2261,6 +2449,20 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/appstream2/latest/APIReference/API_DescribeStacks.html"
+        }
+      },
+      "DescribeUsageReportSubscriptions": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve a list that describes one or more usage report subscriptions",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/appstream2/latest/APIReference/API_DescribeUsageReportSubscriptions.html"
         }
       },
       "DescribeUserStackAssociations": {
@@ -2502,7 +2704,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Grants permission to update the specified Directory Config object in AppStream 2.0. This object includes the information required to join streaming instances to an Active Directory domain",
+        "description": "Grants permission to update the specified Directory Config object in AppStream 2.0. This object includes the configuration information required to join fleets and image builders to Microsoft Active Directory domains",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -2615,7 +2817,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a GraphqlApi object, which is the top level AppSync resource.",
         "docs": {
           "api_doc": "",
@@ -2693,7 +2898,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes a GraphqlApi object. This will also clean up every AppSync resource below that API.",
         "docs": {
           "api_doc": "",
@@ -2761,7 +2968,9 @@
           "ReadOnly"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Retrieves a GraphqlApi object.",
         "docs": {
           "api_doc": "",
@@ -2835,7 +3044,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}using-your-api.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/appsync/latest/APIReference/using-your-api.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/appsync/latest/devguide/using-your-api.html"
         }
       },
       "ListApiKeys": {
@@ -2913,6 +3122,37 @@
           "doc_page_rel": "https://docs.aws.amazon.com/appsync/latest/APIReference/API_ListResolvers.html"
         }
       },
+      "ListResolversByFunction": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "List the resolvers that are associated with a specific function.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/appsync/latest/APIReference/API_ListResolversByFunction.html"
+        }
+      },
+      "ListTagsForResource": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [
+          "aws:ResourceTag/${TagKey}"
+        ],
+        "description": "List the tags for a resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/appsync/latest/APIReference/API_ListTagsForResource.html"
+        }
+      },
       "ListTypes": {
         "aws_action_groups": [
           "ReadWrite",
@@ -2939,6 +3179,40 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/appsync/latest/APIReference/API_StartSchemaCreation.html"
+        }
+      },
+      "TagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}",
+          "aws:TagKeys"
+        ],
+        "description": "Tag a resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/appsync/latest/APIReference/API_TagResource.html"
+        }
+      },
+      "UntagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:TagKeys"
+        ],
+        "description": "Untag a resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/appsync/latest/APIReference/API_UntagResource.html"
         }
       },
       "UpdateApiKey": {
@@ -2985,7 +3259,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Updates a GraphqlApi object.",
         "docs": {
           "api_doc": "",
@@ -3046,7 +3322,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/ApplicationAutoScaling/latest/APIReference/API_DeleteScalingPolicy.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/autoscaling/application/APIReference/API_DeleteScalingPolicy.html"
         }
       },
       "DeleteScheduledAction": {
@@ -3059,7 +3335,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/ApplicationAutoScaling/latest/APIReference/API_DeleteScheduledAction.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/autoscaling/application/APIReference/API_DeleteScheduledAction.html"
         }
       },
       "DeregisterScalableTarget": {
@@ -3072,7 +3348,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/ApplicationAutoScaling/latest/APIReference/API_DeregisterScalableTarget.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/autoscaling/application/APIReference/API_DeregisterScalableTarget.html"
         }
       },
       "DescribeScalableTargets": {
@@ -3086,7 +3362,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/ApplicationAutoScaling/latest/APIReference/API_DescribeScalableTargets.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/autoscaling/application/APIReference/API_DescribeScalableTargets.html"
         }
       },
       "DescribeScalingActivities": {
@@ -3100,7 +3376,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/ApplicationAutoScaling/latest/APIReference/API_DescribeScalingActivities.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/autoscaling/application/APIReference/API_DescribeScalingActivities.html"
         }
       },
       "DescribeScalingPolicies": {
@@ -3114,7 +3390,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/ApplicationAutoScaling/latest/APIReference/API_DescribeScalingPolicies.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/autoscaling/application/APIReference/API_DescribeScalingPolicies.html"
         }
       },
       "DescribeScheduledActions": {
@@ -3128,7 +3404,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/ApplicationAutoScaling/latest/APIReference/API_DescribeScheduledActions.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/autoscaling/application/APIReference/API_DescribeScheduledActions.html"
         }
       },
       "PutScalingPolicy": {
@@ -3141,7 +3417,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/ApplicationAutoScaling/latest/APIReference/API_PutScalingPolicy.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/autoscaling/application/APIReference/API_PutScalingPolicy.html"
         }
       },
       "PutScheduledAction": {
@@ -3154,7 +3430,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/ApplicationAutoScaling/latest/APIReference/API_PutScheduledAction.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/autoscaling/application/APIReference/API_PutScheduledAction.html"
         }
       },
       "RegisterScalableTarget": {
@@ -3167,7 +3443,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/ApplicationAutoScaling/latest/APIReference/API_RegisterScalableTarget.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/autoscaling/application/APIReference/API_RegisterScalableTarget.html"
         }
       }
     },
@@ -5508,7 +5784,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "acm-pca:TemplateArn"
+        ],
         "description": "Issues an ACM Private CA certificate.",
         "docs": {
           "api_doc": "",
@@ -5658,7 +5936,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "ActivateUsers": {
@@ -5671,7 +5949,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}manage-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/manage-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/manage-access.html"
         }
       },
       "AddDomain": {
@@ -5684,7 +5962,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}claim-domain.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/claim-domain.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/claim-domain.html"
         }
       },
       "AddOrUpdateGroups": {
@@ -5697,7 +5975,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}manage-chime-account.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/manage-chime-account.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/manage-chime-account.html"
         }
       },
       "AssociatePhoneNumberWithUser": {
@@ -5736,7 +6014,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "BatchDeletePhoneNumber": {
@@ -5814,7 +6092,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}active_directory.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/active_directory.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/active_directory.html"
         }
       },
       "CreateAccount": {
@@ -5840,7 +6118,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}okta_sso.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/okta_sso.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/okta_sso.html"
         }
       },
       "CreateBot": {
@@ -5879,7 +6157,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}manage-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/manage-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/manage-access.html"
         }
       },
       "CreatePhoneNumberOrder": {
@@ -5931,7 +6209,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}okta_sso.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/okta_sso.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/okta_sso.html"
         }
       },
       "DeleteApiKey": {
@@ -5944,7 +6222,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}okta_sso.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/okta_sso.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/okta_sso.html"
         }
       },
       "DeleteCDRBucket": {
@@ -5957,7 +6235,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "DeleteDelegate": {
@@ -5970,7 +6248,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "DeleteDomain": {
@@ -5983,7 +6261,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}claim-domain.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/claim-domain.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/claim-domain.html"
         }
       },
       "DeleteEventsConfiguration": {
@@ -6009,7 +6287,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "DeletePhoneNumber": {
@@ -6113,7 +6391,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "GetAccount": {
@@ -6141,7 +6419,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "GetAccountSettings": {
@@ -6169,7 +6447,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}okta_sso.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/okta_sso.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/okta_sso.html"
         }
       },
       "GetBot": {
@@ -6197,7 +6475,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "GetDomain": {
@@ -6211,7 +6489,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}claim-domain.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/claim-domain.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/claim-domain.html"
         }
       },
       "GetEventsConfiguration": {
@@ -6253,7 +6531,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "GetPhoneNumber": {
@@ -6295,7 +6573,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}phone-numbers.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/phone-numbers.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/phone-numbers.html"
         }
       },
       "GetUser": {
@@ -6323,7 +6601,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}user-details.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/user-details.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/user-details.html"
         }
       },
       "GetUserByEmail": {
@@ -6337,7 +6615,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}user-details.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/user-details.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/user-details.html"
         }
       },
       "GetUserSettings": {
@@ -6420,7 +6698,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "InviteUsers": {
@@ -6448,7 +6726,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}view-reports.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/view-reports.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/view-reports.html"
         }
       },
       "ListAccounts": {
@@ -6478,7 +6756,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}okta_sso.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/okta_sso.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/okta_sso.html"
         }
       },
       "ListBots": {
@@ -6507,7 +6785,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "ListCallingRegions": {
@@ -6521,7 +6799,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}phone-numbers.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/phone-numbers.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/phone-numbers.html"
         }
       },
       "ListDelegates": {
@@ -6536,7 +6814,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "ListDirectories": {
@@ -6551,7 +6829,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "ListDomains": {
@@ -6566,7 +6844,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}claim-domain.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/claim-domain.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/claim-domain.html"
         }
       },
       "ListGroups": {
@@ -6581,7 +6859,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "ListMeetingEvents": {
@@ -6596,7 +6874,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}view-reports.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/view-reports.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/view-reports.html"
         }
       },
       "ListMeetingsReportData": {
@@ -6611,7 +6889,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}view-reports.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/view-reports.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/view-reports.html"
         }
       },
       "ListPhoneNumberOrders": {
@@ -6773,7 +7051,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}rename-account.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/rename-account.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/rename-account.html"
         }
       },
       "RenewDelegate": {
@@ -6786,7 +7064,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "ResetAccountResource": {
@@ -6799,7 +7077,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "ResetPersonalPIN": {
@@ -6840,7 +7118,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}request-attachments.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/request-attachments.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/request-attachments.html"
         }
       },
       "SearchAvailablePhoneNumbers": {
@@ -6867,7 +7145,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}request-attachments.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/request-attachments.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/request-attachments.html"
         }
       },
       "SubmitSupportRequest": {
@@ -6880,7 +7158,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}chime-getting-admin-support.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/chime-getting-admin-support.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/chime-getting-admin-support.html"
         }
       },
       "SuspendUsers": {
@@ -6893,7 +7171,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}manage-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/manage-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/manage-access.html"
         }
       },
       "UnauthorizeDirectory": {
@@ -6906,7 +7184,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "UpdateAccount": {
@@ -6932,7 +7210,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}okta_sso.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/okta_sso.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/okta_sso.html"
         }
       },
       "UpdateAccountResource": {
@@ -6945,7 +7223,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "UpdateAccountSettings": {
@@ -6984,7 +7262,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       },
       "UpdateGlobalSettings": {
@@ -7023,7 +7301,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}manage-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/manage-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/manage-access.html"
         }
       },
       "UpdateUser": {
@@ -7049,7 +7327,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}manage-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/manage-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/manage-access.html"
         }
       },
       "UpdateUserSettings": {
@@ -7089,7 +7367,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}control-access.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/APIReference/control-access.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/chime/latest/ag/control-access.html"
         }
       }
     },
@@ -7141,7 +7419,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Attaches an existing object to another existing object. ",
+        "description": "Attaches an existing object to another existing object.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -7246,7 +7524,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Creates an index object. ",
+        "description": "Creates an index object.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -7903,7 +8181,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Updates a given typed link\ufffd\ufffd\ufffds attributes. Attributes to be updated must not contribute to the typed link\ufffd\ufffd\ufffds identity, as defined by its IdentityAttributeOrder.",
+        "description": "Updates a given typed link\u00e2\u0080\u0099s attributes. Attributes to be updated must not contribute to the typed link\u00e2\u0080\u0099s identity, as defined by its IdentityAttributeOrder.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -7976,7 +8254,7 @@
         "docs": {
           "api_doc": "API_CreateHttpNamespace.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_CreateHttpNamespace.html"
         }
       },
       "CreatePrivateDnsNamespace": {
@@ -7989,7 +8267,7 @@
         "docs": {
           "api_doc": "API_CreatePrivateDnsNamespace.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_CreatePrivateDnsNamespace.html"
         }
       },
       "CreatePublicDnsNamespace": {
@@ -8002,7 +8280,7 @@
         "docs": {
           "api_doc": "API_CreatePublicDnsNamespace.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_CreatePublicDnsNamespace.html"
         }
       },
       "CreateService": {
@@ -8017,7 +8295,7 @@
         "docs": {
           "api_doc": "API_CreateService.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_CreateService.html"
         }
       },
       "DeleteNamespace": {
@@ -8030,7 +8308,7 @@
         "docs": {
           "api_doc": "API_DeleteNamespace.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_DeleteNamespace.html"
         }
       },
       "DeleteService": {
@@ -8043,7 +8321,7 @@
         "docs": {
           "api_doc": "API_DeleteService.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_DeleteService.html"
         }
       },
       "DeregisterInstance": {
@@ -8058,7 +8336,7 @@
         "docs": {
           "api_doc": "API_DeregisterInstance.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_DeregisterInstance.html"
         }
       },
       "DiscoverInstances": {
@@ -8075,7 +8353,7 @@
         "docs": {
           "api_doc": "API_DiscoverInstances.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_DiscoverInstances.html"
         }
       },
       "GetInstance": {
@@ -8091,7 +8369,7 @@
         "docs": {
           "api_doc": "API_GetInstance.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_GetInstance.html"
         }
       },
       "GetInstancesHealthStatus": {
@@ -8107,7 +8385,7 @@
         "docs": {
           "api_doc": "API_GetInstancesHealthStatus.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_GetInstancesHealthStatus.html"
         }
       },
       "GetNamespace": {
@@ -8121,7 +8399,7 @@
         "docs": {
           "api_doc": "API_GetNamespace.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_GetNamespace.html"
         }
       },
       "GetOperation": {
@@ -8135,7 +8413,7 @@
         "docs": {
           "api_doc": "API_GetOperation.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_GetOperation.html"
         }
       },
       "GetService": {
@@ -8149,7 +8427,7 @@
         "docs": {
           "api_doc": "API_GetService.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_GetService.html"
         }
       },
       "ListInstances": {
@@ -8166,7 +8444,7 @@
         "docs": {
           "api_doc": "API_ListInstances.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_ListInstances.html"
         }
       },
       "ListNamespaces": {
@@ -8181,7 +8459,7 @@
         "docs": {
           "api_doc": "API_ListNamespaces.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_ListNamespaces.html"
         }
       },
       "ListOperations": {
@@ -8196,7 +8474,7 @@
         "docs": {
           "api_doc": "API_ListOperations.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_ListOperations.html"
         }
       },
       "ListServices": {
@@ -8211,7 +8489,7 @@
         "docs": {
           "api_doc": "API_ListServices.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_ListServices.html"
         }
       },
       "RegisterInstance": {
@@ -8226,7 +8504,7 @@
         "docs": {
           "api_doc": "API_RegisterInstance.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_RegisterInstance.html"
         }
       },
       "UpdateInstanceCustomHealthStatus": {
@@ -8241,7 +8519,7 @@
         "docs": {
           "api_doc": "API_UpdateInstanceCustomHealthStatus.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_UpdateInstanceCustomHealthStatus.html"
         }
       },
       "UpdateService": {
@@ -8254,7 +8532,7 @@
         "docs": {
           "api_doc": "API_UpdateService.html",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com//cloud-map/latest/api/API_UpdateService.html"
         }
       }
     },
@@ -8285,11 +8563,11 @@
           "cloud9:SubnetId",
           "cloud9:UserArn"
         ],
-        "description": "Creates an AWS Cloud9 development environment, launches an Amazon Elastic Compute Cloud (Amazon EC2) instance, and then hosts the environment on the instance.",
+        "description": "Grants permission to create an AWS Cloud9 development environment, launches an Amazon Elastic Compute Cloud (Amazon EC2) instance, and then hosts the environment on the instance.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com///cloud9/latest/APIReferenceAPI_CreateEnvironmentEC2.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/cloud9/latest/APIReference/API_CreateEnvironmentEC2.html"
         }
       },
       "CreateEnvironmentMembership": {
@@ -8302,11 +8580,11 @@
           "cloud9:Permissions",
           "cloud9:UserArn"
         ],
-        "description": "Adds an environment member to an AWS Cloud9 development environment.",
+        "description": "Grants permission to add an environment member to an AWS Cloud9 development environment.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com///cloud9/latest/APIReferenceAPI_CreateEnvironmentMembership.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/cloud9/latest/APIReference/API_CreateEnvironmentMembership.html"
         }
       },
       "CreateEnvironmentSSH": {
@@ -8317,7 +8595,7 @@
         "condition_keys": [
           "cloud9:EnvironmentName"
         ],
-        "description": "Creates an AWS Cloud9 development environment, which is connected to a remote SSH server.",
+        "description": "Grants permission to create an AWS Cloud9 development environment, which is connected to a remote SSH server.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -8330,11 +8608,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Deletes an AWS Cloud9 development environment. If the environment is hosted on an Amazon Elastic Compute Cloud (Amazon EC2) instance, also terminates the instance.",
+        "description": "Grants permission to delete an AWS Cloud9 development environment. If the environment is hosted on an Amazon Elastic Compute Cloud (Amazon EC2) instance, also terminates the instance.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com///cloud9/latest/APIReferenceAPI_DeleteEnvironment.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/cloud9/latest/APIReference/API_DeleteEnvironment.html"
         }
       },
       "DeleteEnvironmentMembership": {
@@ -8343,11 +8621,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Deletes an environment member from an AWS Cloud9 development environment.",
+        "description": "Grants permission to delete an environment member from an AWS Cloud9 development environment.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com///cloud9/latest/APIReferenceAPI_DeleteEnvironmentMembership.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/cloud9/latest/APIReference/API_DeleteEnvironmentMembership.html"
         }
       },
       "DescribeEnvironmentMemberships": {
@@ -8360,11 +8638,11 @@
           "cloud9:EnvironmentId",
           "cloud9:UserArn"
         ],
-        "description": "Gets information about environment members for an AWS Cloud9 development environment.",
+        "description": "Grants permission to get information about environment members for an AWS Cloud9 development environment.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com///cloud9/latest/APIReferenceAPI_DescribeEnvironmentMemberships.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/cloud9/latest/APIReference/API_DescribeEnvironmentMemberships.html"
         }
       },
       "DescribeEnvironmentStatus": {
@@ -8374,11 +8652,11 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Gets status information for an AWS Cloud9 development environment.",
+        "description": "Grants permission to get status information for an AWS Cloud9 development environment.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com///cloud9/latest/APIReferenceAPI_DescribeEnvironmentStatus.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/cloud9/latest/APIReference/API_DescribeEnvironmentStatus.html"
         }
       },
       "DescribeEnvironments": {
@@ -8388,11 +8666,11 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Gets information about AWS Cloud9 development environments.",
+        "description": "Grants permission to get information about AWS Cloud9 development environments.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com///cloud9/latest/APIReferenceAPI_DescribeEnvironments.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/cloud9/latest/APIReference/API_DescribeEnvironments.html"
         }
       },
       "GetUserPublicKey": {
@@ -8402,7 +8680,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Gets the public key of the logged in user. Only used in the AWS Cloud9 console.",
+        "description": "Grants permission to get the public key of the logged in user. Only used in the AWS Cloud9 console.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -8416,11 +8694,11 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Gets a list of AWS Cloud9 development environment identifiers.",
+        "description": "Grants permission to get a list of AWS Cloud9 development environment identifiers.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com///cloud9/latest/APIReferenceAPI_ListEnvironments.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/cloud9/latest/APIReference/API_ListEnvironments.html"
         }
       },
       "UpdateEnvironment": {
@@ -8429,11 +8707,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Changes the settings of an existing AWS Cloud9 development environment.",
+        "description": "Grants permission to change the settings of an existing AWS Cloud9 development environment.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com///cloud9/latest/APIReferenceAPI_UpdateEnvironment.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/cloud9/latest/APIReference/API_UpdateEnvironment.html"
         }
       },
       "UpdateEnvironmentMembership": {
@@ -8446,11 +8724,11 @@
           "cloud9:Permissions",
           "cloud9:UserArn"
         ],
-        "description": "Changes the settings of an existing environment member for an AWS Cloud9 development environment.",
+        "description": "Grants permission to change the settings of an existing environment member for an AWS Cloud9 development environment.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com///cloud9/latest/APIReferenceAPI_UpdateEnvironmentMembership.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/cloud9/latest/APIReference/API_UpdateEnvironmentMembership.html"
         }
       },
       "ValidateEnvironmentName": {
@@ -8459,7 +8737,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Checks checks whether the passed in environment is valid. Only used in the AWS Cloud9 console.",
+        "description": "Grants permission to check whether the passed in environment is valid. Only used in the AWS Cloud9 console.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -8521,7 +8799,9 @@
           "cloudformation:ResourceTypes",
           "cloudformation:RoleArn",
           "cloudformation:StackPolicyUrl",
-          "cloudformation:TemplateUrl"
+          "cloudformation:TemplateUrl",
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
         ],
         "description": "Creates a list of changes for a stack.",
         "docs": {
@@ -8539,7 +8819,9 @@
           "cloudformation:ResourceTypes",
           "cloudformation:RoleArn",
           "cloudformation:StackPolicyUrl",
-          "cloudformation:TemplateUrl"
+          "cloudformation:TemplateUrl",
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
         ],
         "description": "Creates a stack as specified in the template.",
         "docs": {
@@ -8568,7 +8850,9 @@
         "calculated_action_group": "Write",
         "condition_keys": [
           "cloudformation:RoleArn",
-          "cloudformation:TemplateUrl"
+          "cloudformation:TemplateUrl",
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
         ],
         "description": "Creates a stackset as specified in the template.",
         "docs": {
@@ -8587,7 +8871,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/"
+          "doc_page_rel": ""
         }
       },
       "DeleteChangeSet": {
@@ -9087,7 +9371,9 @@
           "cloudformation:ResourceTypes",
           "cloudformation:RoleArn",
           "cloudformation:StackPolicyUrl",
-          "cloudformation:TemplateUrl"
+          "cloudformation:TemplateUrl",
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
         ],
         "description": "Updates a stack as specified in the template.",
         "docs": {
@@ -9116,7 +9402,9 @@
         "calculated_action_group": "Write",
         "condition_keys": [
           "cloudformation:RoleArn",
-          "cloudformation:TemplateUrl"
+          "cloudformation:TemplateUrl",
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
         ],
         "description": "Updates a stackset as specified in the template.",
         "docs": {
@@ -10330,7 +10618,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Allows access to the document service operations. ",
+        "description": "Allows access to the document service operations.",
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}configuring-access.html#cloudsearch-actions",
@@ -11220,7 +11508,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/"
+          "doc_page_rel": ""
         }
       },
       "CreateLogGroup": {
@@ -11272,7 +11560,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/"
+          "doc_page_rel": ""
         }
       },
       "DeleteLogGroup": {
@@ -11511,7 +11799,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/"
+          "doc_page_rel": ""
         }
       },
       "GetLogEvents": {
@@ -11582,7 +11870,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/"
+          "doc_page_rel": ""
         }
       },
       "ListTagsLogGroup": {
@@ -11769,7 +12057,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/"
+          "doc_page_rel": ""
         }
       }
     },
@@ -11866,7 +12154,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}auth-and-access-control-iam-identity-based-access-control.html#console-policies",
-          "doc_page_rel": "https://docs.aws.amazon.com/codebuild/latest/APIReference/auth-and-access-control-iam-identity-based-access-control.html#console-policies"
+          "doc_page_rel": "https://docs.aws.amazon.com/codebuild/latest/userguide/auth-and-access-control-iam-identity-based-access-control.html#console-policies"
         }
       },
       "DeleteProject": {
@@ -11976,7 +12264,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}auth-and-access-control-iam-identity-based-access-control.html#console-policies",
-          "doc_page_rel": "https://docs.aws.amazon.com/codebuild/latest/APIReference/auth-and-access-control-iam-identity-based-access-control.html#console-policies"
+          "doc_page_rel": "https://docs.aws.amazon.com/codebuild/latest/userguide/auth-and-access-control-iam-identity-based-access-control.html#console-policies"
         }
       },
       "ListCuratedEnvironmentImages": {
@@ -12021,7 +12309,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}auth-and-access-control-iam-identity-based-access-control.html#console-policies",
-          "doc_page_rel": "https://docs.aws.amazon.com/codebuild/latest/APIReference/auth-and-access-control-iam-identity-based-access-control.html#console-policies"
+          "doc_page_rel": "https://docs.aws.amazon.com/codebuild/latest/userguide/auth-and-access-control-iam-identity-based-access-control.html#console-policies"
         }
       },
       "ListSourceCredentials": {
@@ -12049,7 +12337,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}auth-and-access-control-iam-identity-based-access-control.html#console-policies",
-          "doc_page_rel": "https://docs.aws.amazon.com/codebuild/latest/APIReference/auth-and-access-control-iam-identity-based-access-control.html#console-policies"
+          "doc_page_rel": "https://docs.aws.amazon.com/codebuild/latest/userguide/auth-and-access-control-iam-identity-based-access-control.html#console-policies"
         }
       },
       "StartBuild": {
@@ -12121,6 +12409,20 @@
   },
   "CodeCommit": {
     "actions": {
+      "BatchDescribeMergeConflicts": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to get information about multiple merge conflicts when attempting to merge two commits using either the three-way merge or the squash merge option",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_BatchDescribeMergeConflicts.html"
+        }
+      },
       "BatchGetPullRequests": {
         "aws_action_groups": [
           "ReadOnly",
@@ -12132,7 +12434,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}auth-and-access-control-permissions-reference.html#aa-pr",
-          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/auth-and-access-control-permissions-reference.html#aa-pr"
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control-permissions-reference.html#aa-pr"
         }
       },
       "BatchGetRepositories": {
@@ -12160,7 +12462,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}auth-and-access-control-permissions-reference.html#aa-acp",
-          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/auth-and-access-control-permissions-reference.html#aa-acp"
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control-permissions-reference.html#aa-acp"
         }
       },
       "CreateBranch": {
@@ -12211,12 +12513,30 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Grants permission to create an AWS CodeCommit repository",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_CreateRepository.html"
+        }
+      },
+      "CreateUnreferencedMergeCommit": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "codecommit:References"
+        ],
+        "description": "Grants permission to create an unreferenced commit that contains the result of merging two commits using either the three-way or the squash merge option; does not control Git merge actions",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_CreateUnreferencedMergeCommit.html"
         }
       },
       "DeleteBranch": {
@@ -12273,6 +12593,20 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_DeleteRepository.html"
+        }
+      },
+      "DescribeMergeConflicts": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to get information about specific merge conflicts when attempting to merge two commits using either the three-way or the squash merge option",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_DescribeMergeConflicts.html"
         }
       },
       "DescribePullRequestEvents": {
@@ -12384,7 +12718,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}auth-and-access-control-permissions-reference.html#aa-code",
-          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/auth-and-access-control-permissions-reference.html#aa-code"
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control-permissions-reference.html#aa-code"
         }
       },
       "GetCommitsFromMergeBase": {
@@ -12398,7 +12732,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}auth-and-access-control-permissions-reference.html#aa-pr",
-          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/auth-and-access-control-permissions-reference.html#aa-pr"
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control-permissions-reference.html#aa-pr"
         }
       },
       "GetDifferences": {
@@ -12443,6 +12777,22 @@
           "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_GetFolder.html"
         }
       },
+      "GetMergeCommit": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [
+          "codecommit:References"
+        ],
+        "description": "Grants permission to get information about a merge commit created by one of the merge options for pull requests that creates merge commits. Not all merge options create merge commits. This permission does not control Git merge actions",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_GetMergeCommit.html"
+        }
+      },
       "GetMergeConflicts": {
         "aws_action_groups": [
           "ReadOnly",
@@ -12457,6 +12807,20 @@
           "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_GetMergeConflicts.html"
         }
       },
+      "GetMergeOptions": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to get information about merge options for pull requests that can be used to merge two commits; does not control Git merge actions",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_GetMergeOptions.html"
+        }
+      },
       "GetObjectIdentifier": {
         "aws_action_groups": [
           "ReadOnly",
@@ -12468,7 +12832,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}auth-and-access-control-permissions-reference.html#aa-code",
-          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/auth-and-access-control-permissions-reference.html#aa-code"
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control-permissions-reference.html#aa-code"
         }
       },
       "GetPullRequest": {
@@ -12496,7 +12860,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}auth-and-access-control-permissions-reference.html#aa-code",
-          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/auth-and-access-control-permissions-reference.html#aa-code"
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control-permissions-reference.html#aa-code"
         }
       },
       "GetRepository": {
@@ -12538,7 +12902,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}auth-and-access-control-permissions-reference.html#aa-code",
-          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/auth-and-access-control-permissions-reference.html#aa-code"
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control-permissions-reference.html#aa-code"
         }
       },
       "GetUploadArchiveStatus": {
@@ -12552,7 +12916,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}auth-and-access-control-permissions-reference.html#aa-acp",
-          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/auth-and-access-control-permissions-reference.html#aa-acp"
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control-permissions-reference.html#aa-acp"
         }
       },
       "GitPull": {
@@ -12566,7 +12930,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}auth-and-access-control-permissions-reference.html#aa-git",
-          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/auth-and-access-control-permissions-reference.html#aa-git"
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control-permissions-reference.html#aa-git"
         }
       },
       "GitPush": {
@@ -12581,7 +12945,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}auth-and-access-control-permissions-reference.html#aa-git",
-          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/auth-and-access-control-permissions-reference.html#aa-git"
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control-permissions-reference.html#aa-git"
         }
       },
       "ListBranches": {
@@ -12629,6 +12993,66 @@
           "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_ListRepositories.html"
         }
       },
+      "ListTagsForResource": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Grants permission to list the resource attached to a CodeCommit resource ARN",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_ListTagsForResource.html"
+        }
+      },
+      "MergeBranchesByFastForward": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "codecommit:References"
+        ],
+        "description": "Grants permission to merge two commits into the specified destination branch using the fast-forward merge option",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_MergeBranchesByFastForward.html"
+        }
+      },
+      "MergeBranchesBySquash": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "codecommit:References"
+        ],
+        "description": "Grants permission to merge two commits into the specified destination branch using the squash merge option",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_MergeBranchesBySquash.html"
+        }
+      },
+      "MergeBranchesByThreeWay": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "codecommit:References"
+        ],
+        "description": "Grants permission to merge two commits into the specified destination branch using the three-way merge option",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_MergeBranchesByThreeWay.html"
+        }
+      },
       "MergePullRequestByFastForward": {
         "aws_action_groups": [
           "ReadWrite"
@@ -12642,6 +13066,36 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_MergePullRequestByFastForward.html"
+        }
+      },
+      "MergePullRequestBySquash": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "codecommit:References"
+        ],
+        "description": "Grants permission to close a pull request and attempt to merge it into the specified destination branch for that pull request at the specified commit using the squash merge option",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_MergePullRequestBySquash.html"
+        }
+      },
+      "MergePullRequestByThreeWay": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "codecommit:References"
+        ],
+        "description": "Grants permission to close a pull request and attempt to merge it into the specified destination branch for that pull request at the specified commit using the three-way merge option",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_MergePullRequestByThreeWay.html"
         }
       },
       "PostCommentForComparedCommit": {
@@ -12711,6 +13165,23 @@
           "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_PutRepositoryTriggers.html"
         }
       },
+      "TagResource": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "aws:ResourceTag/${TagKey}",
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
+        "description": "Grants permission to attach resource tags to a CodeCommit resource ARN",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_TagResource.html"
+        }
+      },
       "TestRepositoryTriggers": {
         "aws_action_groups": [
           "ReadWrite"
@@ -12722,6 +13193,21 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_TestRepositoryTriggers.html"
+        }
+      },
+      "UntagResource": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "aws:TagKeys"
+        ],
+        "description": "Grants permission to disassociate resource tags from a CodeCommit resource ARN",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/API_UntagResource.html"
         }
       },
       "UpdateComment": {
@@ -12825,7 +13311,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}auth-and-access-control-permissions-reference.html#aa-acp",
-          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/APIReference/auth-and-access-control-permissions-reference.html#aa-acp"
+          "doc_page_rel": "https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control-permissions-reference.html#aa-acp"
         }
       }
     },
@@ -13410,7 +13896,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Create a custom action you can use in the pipelines associated with your AWS account.",
         "docs": {
           "api_doc": "",
@@ -13423,7 +13912,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Create a uniquely named pipeline.",
         "docs": {
           "api_doc": "",
@@ -13637,6 +14129,20 @@
           "doc_page_rel": "https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_ListPipelines.html"
         }
       },
+      "ListTagsForResource": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Lists tags for a CodePipeline resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_ListTagsForResource.html"
+        }
+      },
       "ListWebhooks": {
         "aws_action_groups": [
           "ListOnly",
@@ -13761,7 +14267,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Create or update a webhook",
         "docs": {
           "api_doc": "",
@@ -13806,6 +14315,39 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_StartPipelineExecution.html"
+        }
+      },
+      "TagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
+        "description": "Tags a CodePipeline resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_TagResource.html"
+        }
+      },
+      "UntagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:TagKeys"
+        ],
+        "description": "Removes a tag from a CodePipeline resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_UntagResource.html"
         }
       },
       "UpdatePipeline": {
@@ -17762,7 +18304,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Grants permissions to modify configuration settings for an existing Amazon Connect instance. The associated required actions grant permission modify the settings for the instance. ",
+        "description": "Grants permissions to modify configuration settings for an existing Amazon Connect instance. The associated required actions grant permission modify the settings for the instance.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -17896,6 +18438,20 @@
           "doc_page_rel": "https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetReservationUtilization.html"
         }
       },
+      "GetRightsizingRecommendation": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve the rightsizing recommendations for your account.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetRightsizingRecommendation.html"
+        }
+      },
       "GetTags": {
         "aws_action_groups": [
           "ReadOnly",
@@ -17908,6 +18464,20 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetTags.html"
+        }
+      },
+      "GetUsageForecast": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve a usage forecast for a forecast time period.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetUsageForecast.html"
         }
       }
     },
@@ -17954,6 +18524,19 @@
           "doc_page_rel": "https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/describe-report-definitions.html"
         }
       },
+      "ModifyReportDefinition": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Modify Cost and Usage Report Definition",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/modify-report-definition.html"
+        }
+      },
       "PutReportDefinition": {
         "aws_action_groups": [
           "ReadWrite"
@@ -17990,7 +18573,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys",
+          "dms:req-tag/${TagKey}"
+        ],
         "description": "Adds metadata tags to a DMS resource, including replication instance, endpoint, security group, and migration task",
         "docs": {
           "api_doc": "",
@@ -17998,12 +18585,29 @@
           "doc_page_rel": "https://docs.aws.amazon.com/dms/latest/APIReference/API_AddTagsToResource.html"
         }
       },
-      "CreateEndpoint": {
+      "ApplyPendingMaintenanceAction": {
         "aws_action_groups": [
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
+        "description": "Applies a pending maintenance action to a resource (for example, to a replication instance).",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/dms/latest/APIReference/API_ApplyPendingMaintenanceAction.html"
+        }
+      },
+      "CreateEndpoint": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys",
+          "dms:req-tag/${TagKey}"
+        ],
         "description": "Creates an endpoint using the provided settings",
         "docs": {
           "api_doc": "",
@@ -18011,12 +18615,33 @@
           "doc_page_rel": "https://docs.aws.amazon.com/dms/latest/APIReference/API_CreateEndpoint.html"
         }
       },
+      "CreateEventSubscription": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys",
+          "dms:req-tag/${TagKey}"
+        ],
+        "description": "Creates an AWS DMS event notification subscription.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/dms/latest/APIReference/API_CreateEventSubscription.html"
+        }
+      },
       "CreateReplicationInstance": {
         "aws_action_groups": [
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys",
+          "dms:req-tag/${TagKey}"
+        ],
         "description": "Creates the replication instance using the specified parameters",
         "docs": {
           "api_doc": "",
@@ -18029,7 +18654,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys",
+          "dms:req-tag/${TagKey}"
+        ],
         "description": "Creates a replication subnet group given a list of the subnet IDs in a VPC",
         "docs": {
           "api_doc": "",
@@ -18042,12 +18671,29 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys",
+          "dms:req-tag/${TagKey}"
+        ],
         "description": "Creates a replication task using the specified parameters",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/dms/latest/APIReference/API_CreateReplicationTask.html"
+        }
+      },
+      "DeleteCertificate": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Deletes the specified certificate",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/dms/latest/APIReference/API_DeleteCertificate.html"
         }
       },
       "DeleteEndpoint": {
@@ -18192,7 +18838,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Lists categories for all event source types, or, if specified, for a specified source type. ",
+        "description": "Lists categories for all event source types, or, if specified, for a specified source type.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -18206,7 +18852,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Lists all the event subscriptions for a customer account. ",
+        "description": "Lists all the event subscriptions for a customer account.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -18220,7 +18866,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Lists events for a given source identifier and source type. ",
+        "description": "Lists events for a given source identifier and source type.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -18255,6 +18901,23 @@
           "doc_page_rel": "https://docs.aws.amazon.com/dms/latest/APIReference/API_DescribeRefreshSchemasStatus.html"
         }
       },
+      "DescribeReplicationInstanceTaskLogs": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [
+          "aws:ResourceTag/${TagKey}",
+          "aws:TagKeys"
+        ],
+        "description": "Returns information about the task logs for the specified task.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/dms/latest/APIReference/API_DescribeReplicationInstanceTaskLogs.html"
+        }
+      },
       "DescribeReplicationInstances": {
         "aws_action_groups": [
           "ReadOnly",
@@ -18281,6 +18944,20 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/dms/latest/APIReference/API_DescribeReplicationSubnetGroups.html"
+        }
+      },
+      "DescribeReplicationTaskAssessmentResults": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Returns the task assessment results from Amazon S3. This action always returns the latest results.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/dms/latest/APIReference/API_DescribeReplicationTaskAssessmentResults.html"
         }
       },
       "DescribeReplicationTasks": {
@@ -18323,6 +19000,22 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/dms/latest/APIReference/API_DescribeTableStatistics.html"
+        }
+      },
+      "ImportCertificate": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
+        "description": "Uploads the specified certificate.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/dms/latest/APIReference/API_ImportCertificate.html"
         }
       },
       "ListTagsForResource": {
@@ -18405,6 +19098,19 @@
           "doc_page_rel": "https://docs.aws.amazon.com/dms/latest/APIReference/API_ModifyReplicationTask.html"
         }
       },
+      "RebootReplicationInstance": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Reboots a replication instance. Rebooting results in a momentary outage, until the replication instance becomes available again.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/dms/latest/APIReference/API_RebootReplicationInstance.html"
+        }
+      },
       "RefreshSchemas": {
         "aws_action_groups": [
           "ReadWrite"
@@ -18418,13 +19124,28 @@
           "doc_page_rel": "https://docs.aws.amazon.com/dms/latest/APIReference/API_RefreshSchemas.html"
         }
       },
+      "ReloadTables": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Reloads the target database table with the source data.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/dms/latest/APIReference/API_ReloadTables.html"
+        }
+      },
       "RemoveTagsFromResource": {
         "aws_action_groups": [
           "Tagging",
           "ReadWrite"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:TagKeys"
+        ],
         "description": "Removes metadata tags from a DMS resource",
         "docs": {
           "api_doc": "",
@@ -18443,6 +19164,19 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/dms/latest/APIReference/API_StartReplicationTask.html"
+        }
+      },
+      "StartReplicationTaskAssessment": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Starts the replication task assessment for unsupported data types in the source database.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/dms/latest/APIReference/API_StartReplicationTaskAssessment.html"
         }
       },
       "StopReplicationTask": {
@@ -18935,7 +19669,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_CancelTaskExecution.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_CancelTaskExecution.html"
         }
       },
       "CreateAgent": {
@@ -18951,7 +19685,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_CreateAgent.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_CreateAgent.html"
         }
       },
       "CreateLocationEfs": {
@@ -18967,7 +19701,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_CreateLocationEfs.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_CreateLocationEfs.html"
         }
       },
       "CreateLocationNfs": {
@@ -18983,7 +19717,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_CreateLocationNfs.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_CreateLocationNfs.html"
         }
       },
       "CreateLocationS3": {
@@ -18999,7 +19733,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_CreateLocationS3.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_CreateLocationS3.html"
         }
       },
       "CreateTask": {
@@ -19015,7 +19749,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_CreateTask.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_CreateTask.html"
         }
       },
       "DeleteAgent": {
@@ -19030,7 +19764,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_DeleteAgent.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_DeleteAgent.html"
         }
       },
       "DeleteLocation": {
@@ -19045,7 +19779,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_DeleteLocation.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_DeleteLocation.html"
         }
       },
       "DeleteTask": {
@@ -19058,7 +19792,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_DeleteTask.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_DeleteTask.html"
         }
       },
       "DescribeAgent": {
@@ -19074,7 +19808,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_DescribeAgent.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_DescribeAgent.html"
         }
       },
       "DescribeLocationEfs": {
@@ -19090,7 +19824,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_DescribeLocationEfs.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_DescribeLocationEfs.html"
         }
       },
       "DescribeLocationNfs": {
@@ -19106,7 +19840,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_DescribeLocationNfs.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_DescribeLocationNfs.html"
         }
       },
       "DescribeLocationS3": {
@@ -19122,7 +19856,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_DescribeLocationS3.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_DescribeLocationS3.html"
         }
       },
       "DescribeTask": {
@@ -19138,7 +19872,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_DescribeTask.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_DescribeTask.html"
         }
       },
       "DescribeTaskExecution": {
@@ -19152,7 +19886,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_DescribeTaskExecution.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_DescribeTaskExecution.html"
         }
       },
       "ListAgents": {
@@ -19167,7 +19901,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_ListAgents.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_ListAgents.html"
         }
       },
       "ListLocations": {
@@ -19182,7 +19916,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_ListLocations.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_ListLocations.html"
         }
       },
       "ListTagsForResource": {
@@ -19198,7 +19932,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_ListTagsForResource.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_ListTagsForResource.html"
         }
       },
       "ListTaskExecutions": {
@@ -19213,7 +19947,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_ListTaskExecutions.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_ListTaskExecutions.html"
         }
       },
       "ListTasks": {
@@ -19228,7 +19962,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_ListTasks.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_ListTasks.html"
         }
       },
       "StartTaskExecution": {
@@ -19243,7 +19977,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_StartTaskExecution.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_StartTaskExecution.html"
         }
       },
       "TagResource": {
@@ -19259,7 +19993,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_TagResource.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_TagResource.html"
         }
       },
       "UntagResource": {
@@ -19275,7 +20009,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_UntagResource.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_UntagResource.html"
         }
       },
       "UpdateAgent": {
@@ -19290,7 +20024,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_UpdateAgent.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_UpdateAgent.html"
         }
       },
       "UpdateTask": {
@@ -19305,7 +20039,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/APIReference/API_UpdateTask.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/datasync/latest/userguide/API_UpdateTask.html"
         }
       }
     },
@@ -20354,6 +21088,19 @@
   },
   "Direct Connect": {
     "actions": {
+      "AcceptDirectConnectGatewayAssociationProposal": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Accepts a proposal request to attach a virtual private gateway to a Direct Connect gateway.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/directconnect/latest/APIReference/API_AcceptDirectConnectGatewayAssociationProposal.html"
+        }
+      },
       "AllocateConnectionOnInterconnect": {
         "aws_action_groups": [
           "ReadWrite"
@@ -20372,7 +21119,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a new hosted connection between a AWS Direct Connect partner's network and a specific AWS Direct Connect location.",
         "docs": {
           "api_doc": "",
@@ -20385,7 +21135,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Provisions a private virtual interface to be owned by a different customer.",
         "docs": {
           "api_doc": "",
@@ -20398,12 +21151,31 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Provisions a public virtual interface to be owned by a different customer.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/directconnect/latest/APIReference/API_AllocatePublicVirtualInterface.html"
+        }
+      },
+      "AllocateTransitVirtualInterface": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
+        "description": "Provisions a transit virtual interface to be owned by a different customer.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/directconnect/latest/APIReference/API_AllocateTransitVirtualInterface.html"
         }
       },
       "AssociateConnectionWithLag": {
@@ -20447,10 +21219,9 @@
       },
       "ConfirmConnection": {
         "aws_action_groups": [
-          "ReadOnly",
           "ReadWrite"
         ],
-        "calculated_action_group": "Read",
+        "calculated_action_group": "Write",
         "condition_keys": [],
         "description": "Confirm the creation of a hosted connection on an interconnect.",
         "docs": {
@@ -20461,10 +21232,9 @@
       },
       "ConfirmPrivateVirtualInterface": {
         "aws_action_groups": [
-          "ReadOnly",
           "ReadWrite"
         ],
-        "calculated_action_group": "Read",
+        "calculated_action_group": "Write",
         "condition_keys": [],
         "description": "Accept ownership of a private virtual interface created by another customer.",
         "docs": {
@@ -20475,16 +21245,28 @@
       },
       "ConfirmPublicVirtualInterface": {
         "aws_action_groups": [
-          "ReadOnly",
           "ReadWrite"
         ],
-        "calculated_action_group": "Read",
+        "calculated_action_group": "Write",
         "condition_keys": [],
         "description": "Accept ownership of a public virtual interface created by another customer",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/directconnect/latest/APIReference/API_ConfirmPublicVirtualInterface.html"
+        }
+      },
+      "ConfirmTransitVirtualInterface": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Accept ownership of a transit virtual interface created by another customer",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/directconnect/latest/APIReference/API_ConfirmTransitVirtualInterface.html"
         }
       },
       "CreateBGPPeer": {
@@ -20505,7 +21287,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a new connection between the customer network and a specific AWS Direct Connect location.",
         "docs": {
           "api_doc": "",
@@ -20539,12 +21324,28 @@
           "doc_page_rel": "https://docs.aws.amazon.com/directconnect/latest/APIReference/API_CreateDirectConnectGatewayAssociation.html"
         }
       },
-      "CreateInterconnect": {
+      "CreateDirectConnectGatewayAssociationProposal": {
         "aws_action_groups": [
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
+        "description": "Creates a proposal to associate the specified virtual private gateway with the specified Direct Connect gateway.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/directconnect/latest/APIReference/API_CreateDirectConnectGatewayAssociationProposal.html"
+        }
+      },
+      "CreateInterconnect": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a new interconnect between a AWS Direct Connect partner's network and a specific AWS Direct Connect location.",
         "docs": {
           "api_doc": "",
@@ -20557,7 +21358,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a link aggregation group (LAG) with the specified number of bundled physical connections between the customer network and a specific AWS Direct Connect location.",
         "docs": {
           "api_doc": "",
@@ -20570,7 +21374,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a new private virtual interface.",
         "docs": {
           "api_doc": "",
@@ -20583,12 +21390,31 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a new public virtual interface.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/directconnect/latest/APIReference/API_CreatePublicVirtualInterface.html"
+        }
+      },
+      "CreateTransitVirtualInterface": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
+        "description": "Creates a new transit virtual interface.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/directconnect/latest/APIReference/API_CreateTransitVirtualInterface.html"
         }
       },
       "DeleteBGPPeer": {
@@ -20641,6 +21467,19 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DeleteDirectConnectGatewayAssociation.html"
+        }
+      },
+      "DeleteDirectConnectGatewayAssociationProposal": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Deletes the association proposal request between the specified Direct Connect gateway and virtual private gateway.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DeleteDirectConnectGatewayAssociationProposal.html"
         }
       },
       "DeleteInterconnect": {
@@ -20722,6 +21561,20 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeConnectionsOnInterconnect.html"
+        }
+      },
+      "DescribeDirectConnectGatewayAssociationProposals": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Describes one or more association proposals for connection between a virtual private gateway and a Direct Connect gateway.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeDirectConnectGatewayAssociationProposals.html"
         }
       },
       "DescribeDirectConnectGatewayAssociations": {
@@ -20838,10 +21691,11 @@
       },
       "DescribeLocations": {
         "aws_action_groups": [
+          "ListOnly",
           "ReadOnly",
           "ReadWrite"
         ],
-        "calculated_action_group": "Read",
+        "calculated_action_group": "List",
         "condition_keys": [],
         "description": "Returns the list of AWS Direct Connect locations in the current AWS region.",
         "docs": {
@@ -20894,10 +21748,9 @@
       },
       "DisassociateConnectionFromLag": {
         "aws_action_groups": [
-          "ReadOnly",
           "ReadWrite"
         ],
-        "calculated_action_group": "Read",
+        "calculated_action_group": "Write",
         "condition_keys": [],
         "description": "Disassociates a connection from a link aggregation group (LAG).",
         "docs": {
@@ -20912,7 +21765,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Adds the specified tags to the specified AWS Direct Connect resource. Each resource can have a maximum of 50 tags.",
         "docs": {
           "api_doc": "",
@@ -20926,7 +21782,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:TagKeys"
+        ],
         "description": "Removes one or more tags from the specified AWS Direct Connect resource.",
         "docs": {
           "api_doc": "",
@@ -20934,12 +21792,24 @@
           "doc_page_rel": "https://docs.aws.amazon.com/directconnect/latest/APIReference/API_UntagResource.html"
         }
       },
-      "UpdateLag": {
+      "UpdateDirectConnectGatewayAssociation": {
         "aws_action_groups": [
-          "ReadOnly",
           "ReadWrite"
         ],
-        "calculated_action_group": "Read",
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Updates the specified attributes of the Direct Connect gateway association.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/directconnect/latest/APIReference/API_UpdateDirectConnectGatewayAssociation.html"
+        }
+      },
+      "UpdateLag": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
         "condition_keys": [],
         "description": "Updates the attributes of the specified link aggregation group (LAG).",
         "docs": {
@@ -20950,10 +21820,9 @@
       },
       "UpdateVirtualInterfaceAttributes": {
         "aws_action_groups": [
-          "ReadOnly",
           "ReadWrite"
         ],
-        "calculated_action_group": "Read",
+        "calculated_action_group": "Write",
         "condition_keys": [],
         "description": "Updates the specified attributes of the specified virtual private interface.",
         "docs": {
@@ -21135,7 +22004,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/directoryservice/latest/devguide/"
+          "doc_page_rel": ""
         }
       },
       "CreateLogSubscription": {
@@ -22819,7 +23688,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Accepts a request to attach a VPC to a transit gateway",
         "docs": {
           "api_doc": "",
@@ -22845,7 +23717,13 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Tenancy",
+          "ec2:AccepterVpc",
+          "ec2:RequesterVpc"
+        ],
         "description": "Accept a VPC peering connection request.",
         "docs": {
           "api_doc": "",
@@ -22897,7 +23775,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Applies a security group to the association between the target network and the Client VPN endpoint.",
         "docs": {
           "api_doc": "",
@@ -22949,7 +23830,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Associates a target network with a Client VPN endpoint.",
         "docs": {
           "api_doc": "",
@@ -22975,7 +23859,17 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:AvailabilityZone",
+          "ec2:EbsOptimized",
+          "ec2:InstanceProfile",
+          "ec2:InstanceType",
+          "ec2:PlacementGroup",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:RootDeviceType",
+          "ec2:Tenancy"
+        ],
         "description": "Associates an IAM instance profile with a running or stopped instance.",
         "docs": {
           "api_doc": "",
@@ -23014,7 +23908,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Associates the specified attachment with the specified transit gateway route table",
         "docs": {
           "api_doc": "",
@@ -23040,7 +23937,18 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:AvailabilityZone",
+          "ec2:EbsOptimized",
+          "ec2:InstanceProfile",
+          "ec2:InstanceType",
+          "ec2:PlacementGroup",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:RootDeviceType",
+          "ec2:Tenancy",
+          "ec2:Vpc"
+        ],
         "description": "Links an EC2-Classic instance to a ClassicLink-enabled VPC through one or more of the VPC's security groups.",
         "docs": {
           "api_doc": "",
@@ -23079,7 +23987,22 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:AvailabilityZone",
+          "ec2:EbsOptimized",
+          "ec2:InstanceProfile",
+          "ec2:InstanceType",
+          "ec2:PlacementGroup",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:RootDeviceType",
+          "ec2:Tenancy",
+          "ec2:Encrypted",
+          "ec2:ParentSnapshot",
+          "ec2:VolumeIops",
+          "ec2:VolumeSize",
+          "ec2:VolumeType"
+        ],
         "description": "Attaches an EBS volume to a running or stopped instance and exposes it to the instance with the specified device name.",
         "docs": {
           "api_doc": "",
@@ -23105,7 +24028,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Adds an ingress authorization rule to a Client VPN endpoint.",
         "docs": {
           "api_doc": "",
@@ -23118,7 +24044,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Vpc"
+        ],
         "description": "[EC2-VPC only] Adds one or more egress rules to a security group for use with a VPC.",
         "docs": {
           "api_doc": "",
@@ -23131,7 +24061,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Vpc"
+        ],
         "description": "Adds one or more ingress rules to a security group.",
         "docs": {
           "api_doc": "",
@@ -23170,7 +24104,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Cancels the specified Capacity Reservation, releases the reserved capacity, and changes the Capacity Reservation's state to cancelled.",
         "docs": {
           "api_doc": "",
@@ -23326,7 +24263,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys",
+          "ec2:Region"
+        ],
         "description": "Creates a Client VPN endpoint.",
         "docs": {
           "api_doc": "",
@@ -23339,7 +24280,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Adds a route to a network to a Client VPN endpoint.",
         "docs": {
           "api_doc": "",
@@ -23521,7 +24465,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Creates a new version for the specified launch template.",
         "docs": {
           "api_doc": "",
@@ -23586,7 +24533,16 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:AuthorizedUser",
+          "ec2:AvailabilityZone",
+          "ec2:Permission",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Subnet",
+          "ec2:Vpc",
+          "ec2:AuthorizedService"
+        ],
         "description": "Creates a permission for a network interface that grants certain operations to another authorized user.",
         "docs": {
           "api_doc": "",
@@ -23625,7 +24581,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Vpc"
+        ],
         "description": "Creates a route in a route table within a VPC.",
         "docs": {
           "api_doc": "",
@@ -23664,12 +24624,55 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:TagKeys",
+          "aws:RequestTag/${TagKey}",
+          "ec2:ParentVolume",
+          "ec2:Region",
+          "ec2:Encrypted",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:VolumeIops",
+          "ec2:VolumeSize",
+          "ec2:VolumeType"
+        ],
         "description": "Creates a snapshot of an EBS volume and stores it in Amazon S3.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateSnapshot.html"
+        }
+      },
+      "CreateSnapshots": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "ec2:AvailabilityZone",
+          "ec2:EbsOptimized",
+          "ec2:InstanceProfile",
+          "ec2:InstanceType",
+          "ec2:PlacementGroup",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:RootDeviceType",
+          "ec2:Tenancy",
+          "aws:TagKeys",
+          "aws:RequestTag/${TagKey}",
+          "ec2:ParentVolume",
+          "ec2:Region",
+          "ec2:Encrypted",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:VolumeIops",
+          "ec2:VolumeSize",
+          "ec2:VolumeType"
+        ],
+        "description": "Creates a snapshots of an EBS volumes which attached to an EC2 instance and stores them in Amazon S3.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateSnapshots.html"
         }
       },
       "CreateSpotDatafeedSubscription": {
@@ -23705,7 +24708,31 @@
         ],
         "calculated_action_group": "Tagging",
         "condition_keys": [
-          "ec2:CreateAction"
+          "ec2:CreateAction",
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Owner",
+          "ec2:Public",
+          "ec2:ImageType",
+          "ec2:RootDeviceType",
+          "ec2:AvailabilityZone",
+          "ec2:EbsOptimized",
+          "ec2:InstanceProfile",
+          "ec2:InstanceType",
+          "ec2:PlacementGroup",
+          "ec2:Tenancy",
+          "ec2:Vpc",
+          "ec2:Subnet",
+          "ec2:ReservedInstancesOfferingType",
+          "ec2:ParentVolume",
+          "ec2:SnapshotTime",
+          "ec2:VolumeSize",
+          "ec2:Encrypted",
+          "ec2:ParentSnapshot",
+          "ec2:VolumeIops",
+          "ec2:VolumeType"
         ],
         "description": "Adds or overwrites one or more tags for the specified Amazon EC2 resource or resources.",
         "docs": {
@@ -23719,7 +24746,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys",
+          "ec2:Region"
+        ],
         "description": "Creates a transit gateway.",
         "docs": {
           "api_doc": "",
@@ -23732,7 +24763,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Creates a static route for the specified transit gateway route table.",
         "docs": {
           "api_doc": "",
@@ -23745,7 +24779,12 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a route table for the specified transit gateway.",
         "docs": {
           "api_doc": "",
@@ -23758,7 +24797,12 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Attaches the specified VPC to the specified transit gateway.",
         "docs": {
           "api_doc": "",
@@ -23771,7 +24815,17 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys",
+          "ec2:AvailabilityZone",
+          "ec2:Encrypted",
+          "ec2:ParentSnapshot",
+          "ec2:Region",
+          "ec2:VolumeIops",
+          "ec2:VolumeSize",
+          "ec2:VolumeType"
+        ],
         "description": "Creates an EBS volume that can be attached to an instance in the same Availability Zone.",
         "docs": {
           "api_doc": "",
@@ -23836,7 +24890,13 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Tenancy",
+          "ec2:AccepterVpc",
+          "ec2:RequesterVpc"
+        ],
         "description": "Requests a VPC peering connection between two VPCs: a requester VPC that you own and a peer VPC with which to create the connection.",
         "docs": {
           "api_doc": "",
@@ -23888,7 +24948,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes the specified Client VPN endpoint.",
         "docs": {
           "api_doc": "",
@@ -23901,7 +24964,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes a route from a Client VPN endpoint.",
         "docs": {
           "api_doc": "",
@@ -23914,7 +24980,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes the specified customer gateway.",
         "docs": {
           "api_doc": "",
@@ -23927,7 +24996,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes the specified set of DHCP options.",
         "docs": {
           "api_doc": "",
@@ -23992,7 +25064,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes the specified Internet gateway.",
         "docs": {
           "api_doc": "",
@@ -24018,7 +25093,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes the specified launch template and all associated versions.",
         "docs": {
           "api_doc": "",
@@ -24031,7 +25109,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes the specified versions for the specified launch template.",
         "docs": {
           "api_doc": "",
@@ -24057,7 +25138,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Vpc"
+        ],
         "description": "Deletes the specified network ACL.",
         "docs": {
           "api_doc": "",
@@ -24070,7 +25155,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Vpc"
+        ],
         "description": "Deletes the specified ingress or egress entry (rule) from the specified network ACL.",
         "docs": {
           "api_doc": "",
@@ -24122,7 +25211,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Vpc"
+        ],
         "description": "Deletes the specified route from the specified route table.",
         "docs": {
           "api_doc": "",
@@ -24135,7 +25228,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Vpc"
+        ],
         "description": "Deletes the specified route table.",
         "docs": {
           "api_doc": "",
@@ -24148,7 +25245,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Vpc"
+        ],
         "description": "Deletes a security group.",
         "docs": {
           "api_doc": "",
@@ -24161,7 +25262,14 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Owner",
+          "ec2:ParentVolume",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:SnapshotTime",
+          "ec2:VolumeSize"
+        ],
         "description": "Deletes the specified snapshot.",
         "docs": {
           "api_doc": "",
@@ -24201,7 +25309,12 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes the specified set of tags from the specified set of resources.",
         "docs": {
           "api_doc": "",
@@ -24214,7 +25327,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes the specified transit gateway.",
         "docs": {
           "api_doc": "",
@@ -24227,7 +25343,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes the specified route from the specified transit gateway route table.",
         "docs": {
           "api_doc": "",
@@ -24240,7 +25359,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes the specified transit gateway route table.",
         "docs": {
           "api_doc": "",
@@ -24253,7 +25375,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes the specified VPC attachment.",
         "docs": {
           "api_doc": "",
@@ -24266,7 +25391,16 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:AvailabilityZone",
+          "ec2:Encrypted",
+          "ec2:ParentSnapshot",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:VolumeIops",
+          "ec2:VolumeSize",
+          "ec2:VolumeType"
+        ],
         "description": "Deletes the specified EBS volume.",
         "docs": {
           "api_doc": "",
@@ -24331,7 +25465,12 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:AccepterVpc",
+          "ec2:Region",
+          "ec2:RequesterVpc",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Description for DeleteVpcPeeringConnection",
         "docs": {
           "api_doc": "",
@@ -25828,7 +26967,17 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:AvailabilityZone",
+          "ec2:EbsOptimized",
+          "ec2:InstanceProfile",
+          "ec2:InstanceType",
+          "ec2:PlacementGroup",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:RootDeviceType",
+          "ec2:Tenancy"
+        ],
         "description": "Unlinks (detaches) a linked EC2-Classic instance from a VPC.",
         "docs": {
           "api_doc": "",
@@ -25867,7 +27016,22 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:AvailabilityZone",
+          "ec2:EbsOptimized",
+          "ec2:InstanceProfile",
+          "ec2:InstanceType",
+          "ec2:PlacementGroup",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:RootDeviceType",
+          "ec2:Tenancy",
+          "ec2:Encrypted",
+          "ec2:ParentSnapshot",
+          "ec2:VolumeIops",
+          "ec2:VolumeSize",
+          "ec2:VolumeType"
+        ],
         "description": "Detaches an EBS volume from an instance.",
         "docs": {
           "api_doc": "",
@@ -25888,12 +27052,28 @@
           "doc_page_rel": "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DetachVpnGateway.html"
         }
       },
-      "DisableTransitGatewayRouteTablePropagation": {
+      "DisableEbsEncryptionByDefault": {
         "aws_action_groups": [
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
+        "description": "Disable the default EBS encryption by enabled for your account in the current region",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DisableEbsEncryptionByDefault.html"
+        }
+      },
+      "DisableTransitGatewayRouteTablePropagation": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Disables the specified resource attachment from propagating routes to the specified propagation route table.",
         "docs": {
           "api_doc": "",
@@ -25919,7 +27099,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Tenancy"
+        ],
         "description": "Disables ClassicLink for a VPC.",
         "docs": {
           "api_doc": "",
@@ -25958,7 +27142,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Disassociates a target network from the specified Client VPN endpoint.",
         "docs": {
           "api_doc": "",
@@ -25971,7 +27158,17 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:AvailabilityZone",
+          "ec2:EbsOptimized",
+          "ec2:InstanceProfile",
+          "ec2:InstanceType",
+          "ec2:PlacementGroup",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:RootDeviceType",
+          "ec2:Tenancy"
+        ],
         "description": "Disassociates an IAM instance profile from a running or stopped instance.",
         "docs": {
           "api_doc": "",
@@ -26010,7 +27207,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Disassociates a resource attachment from a transit gateway route table.",
         "docs": {
           "api_doc": "",
@@ -26031,12 +27231,28 @@
           "doc_page_rel": "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DisassociateVpcCidrBlock.html"
         }
       },
-      "EnableTransitGatewayRouteTablePropagation": {
+      "EnableEbsEncryptionByDefault": {
         "aws_action_groups": [
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
+        "description": "Enables EBS encryption by default for your account in the current Region",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EnableEbsEncryptionByDefault.html"
+        }
+      },
+      "EnableTransitGatewayRouteTablePropagation": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Enables the specified attachment to propagate routes to the specified propagation route table.",
         "docs": {
           "api_doc": "",
@@ -26075,7 +27291,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Tenancy"
+        ],
         "description": "Enables a VPC for ClassicLink.",
         "docs": {
           "api_doc": "",
@@ -26159,12 +27379,50 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:AvailabilityZone",
+          "ec2:EbsOptimized",
+          "ec2:InstanceProfile",
+          "ec2:InstanceType",
+          "ec2:PlacementGroup",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:RootDeviceType",
+          "ec2:Tenancy"
+        ],
         "description": "Retrieve a JPG-format screenshot of a running instance to help with troubleshooting.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetConsoleScreenshot.html"
+        }
+      },
+      "GetEbsDefaultKmsKeyId": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Get EBS Default Kms Key Id",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetEbsDefaultKmsKeyId.html"
+        }
+      },
+      "GetEbsEncryptionByDefault": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Describes whether EBS encryption by default is enabled for your account in the current Region",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetEbsEncryptionByDefault.html"
         }
       },
       "GetHostReservationPurchasePreview": {
@@ -26273,7 +27531,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Uploads a client certificate revocation list to the specified Client VPN endpoint.",
         "docs": {
           "api_doc": "",
@@ -26351,7 +27612,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Modifies a Capacity Reservation's capacity and the conditions under which it is to be released.",
         "docs": {
           "api_doc": "",
@@ -26364,12 +27628,28 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Modifies the specified Client VPN endpoint.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyClientVpnEndpoint.html"
+        }
+      },
+      "ModifyEbsDefaultKmsKeyId": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Changes the default customer master key (CMK) for EBS encryption by default for your account in this Region",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/ModifyEbsDefaultKmsKeyId.html"
         }
       },
       "ModifyFleet": {
@@ -26494,7 +27774,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region"
+        ],
         "description": "Modifies the start time for a scheduled EC2 instance event.",
         "docs": {
           "api_doc": "",
@@ -26520,7 +27802,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Modifies the specified launch template.",
         "docs": {
           "api_doc": "",
@@ -26559,7 +27844,14 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Owner",
+          "ec2:ParentVolume",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:SnapshotTime",
+          "ec2:VolumeSize"
+        ],
         "description": "Adds or removes permission settings for the specified snapshot.",
         "docs": {
           "api_doc": "",
@@ -26598,7 +27890,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Modifies the specified VPC attachment.",
         "docs": {
           "api_doc": "",
@@ -26612,7 +27907,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "You can modify several parameters of an existing EBS volume, including volume size, volume type, and IOPS capacity. ",
+        "description": "You can modify several parameters of an existing EBS volume, including volume size, volume type, and IOPS capacity.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -26723,6 +28018,19 @@
           "doc_page_rel": "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyVpcTenancy.html"
         }
       },
+      "ModifyVpnConnection": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Modifies the target gateway of a AWS Site-to-Site VPN connection",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyVpnConnection.html"
+        }
+      },
       "MonitorInstances": {
         "aws_action_groups": [
           "ReadWrite"
@@ -26806,7 +28114,17 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:AvailabilityZone",
+          "ec2:EbsOptimized",
+          "ec2:InstanceProfile",
+          "ec2:InstanceType",
+          "ec2:PlacementGroup",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:RootDeviceType",
+          "ec2:Tenancy"
+        ],
         "description": "Requests a reboot of one or more instances.",
         "docs": {
           "api_doc": "",
@@ -26832,7 +28150,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Rejects a request to attach a VPC to a transit gateway.",
         "docs": {
           "api_doc": "",
@@ -26858,7 +28179,12 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:AccepterVpc",
+          "ec2:Region",
+          "ec2:RequesterVpc",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Rejects a VPC peering connection request.",
         "docs": {
           "api_doc": "",
@@ -26897,7 +28223,17 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:AvailabilityZone",
+          "ec2:EbsOptimized",
+          "ec2:InstanceProfile",
+          "ec2:InstanceType",
+          "ec2:PlacementGroup",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:RootDeviceType",
+          "ec2:Tenancy"
+        ],
         "description": "Replaces an IAM instance profile for the specified instance.",
         "docs": {
           "api_doc": "",
@@ -26936,7 +28272,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Vpc"
+        ],
         "description": "Replaces an existing route within a route table in a VPC.",
         "docs": {
           "api_doc": "",
@@ -26962,7 +28302,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Replaces the specified route in the specified transit gateway route table.",
         "docs": {
           "api_doc": "",
@@ -27007,6 +28350,19 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotInstances.html"
+        }
+      },
+      "ResetEbsDefaultKmsKeyId": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Resets the default customer master key (CMK) for EBS encryption for your account in this Region to the AWS managed CMK for EBS",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/ResetEbsDefaultKmsKeyId.html"
         }
       },
       "ResetFpgaImageAttribute": {
@@ -27080,7 +28436,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Restores an Elastic IP address that was previously moved to the EC2-VPC platform back to the EC2-Classic platform. ",
+        "description": "Restores an Elastic IP address that was previously moved to the EC2-VPC platform back to the EC2-Classic platform.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -27092,7 +28448,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Removes an ingress authorization rule from a Client VPN endpoint.",
         "docs": {
           "api_doc": "",
@@ -27105,7 +28464,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Vpc"
+        ],
         "description": "[EC2-VPC only] Removes one or more egress rules from a security group for EC2-VPC. This action doesn't apply to security groups for use in EC2-Classic.",
         "docs": {
           "api_doc": "",
@@ -27118,7 +28481,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Vpc"
+        ],
         "description": "Removes one or more ingress rules from a security group.",
         "docs": {
           "api_doc": "",
@@ -27132,7 +28499,35 @@
           "Tagging"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:ImageType",
+          "ec2:IsLaunchTemplateResource",
+          "ec2:LaunchTemplate",
+          "ec2:Owner",
+          "ec2:Public",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:RootDeviceType",
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys",
+          "ec2:AvailabilityZone",
+          "ec2:EbsOptimized",
+          "ec2:InstanceProfile",
+          "ec2:InstanceType",
+          "ec2:PlacementGroup",
+          "ec2:Tenancy",
+          "ec2:ResourceTag/",
+          "ec2:Subnet",
+          "ec2:Vpc",
+          "ec2:Encrypted",
+          "ec2:ParentSnapshot",
+          "ec2:VolumeIops",
+          "ec2:VolumeSize",
+          "ec2:VolumeType",
+          "ec2:PlacementGroupStrategy",
+          "ec2:ParentVolume",
+          "ec2:SnapshotTime"
+        ],
         "description": "Launches the specified number of instances using an AMI for which you have permissions.",
         "docs": {
           "api_doc": "",
@@ -27173,7 +28568,17 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:AvailabilityZone",
+          "ec2:EbsOptimized",
+          "ec2:InstanceProfile",
+          "ec2:InstanceType",
+          "ec2:PlacementGroup",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:RootDeviceType",
+          "ec2:Tenancy"
+        ],
         "description": "Starts an Amazon EBS-backed AMI that you've previously stopped.",
         "docs": {
           "api_doc": "",
@@ -27186,7 +28591,17 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:AvailabilityZone",
+          "ec2:EbsOptimized",
+          "ec2:InstanceProfile",
+          "ec2:InstanceType",
+          "ec2:PlacementGroup",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:RootDeviceType",
+          "ec2:Tenancy"
+        ],
         "description": "Stops an Amazon EBS-backed instance.",
         "docs": {
           "api_doc": "",
@@ -27199,7 +28614,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}"
+        ],
         "description": "Terminates active Client VPN endpoint connections.",
         "docs": {
           "api_doc": "",
@@ -27212,7 +28630,17 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:AvailabilityZone",
+          "ec2:EbsOptimized",
+          "ec2:InstanceProfile",
+          "ec2:InstanceType",
+          "ec2:PlacementGroup",
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:RootDeviceType",
+          "ec2:Tenancy"
+        ],
         "description": "Shuts down one or more instances.",
         "docs": {
           "api_doc": "",
@@ -27264,7 +28692,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Vpc"
+        ],
         "description": "[EC2-VPC only] Update descriptions for one or more egress rules of a security group. This action doesn't apply to security groups for use in EC2-Classic.",
         "docs": {
           "api_doc": "",
@@ -27277,7 +28709,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ec2:Region",
+          "ec2:ResourceTag/${TagKey}",
+          "ec2:Vpc"
+        ],
         "description": "Update descriptions for one or more ingress rules of a security group.",
         "docs": {
           "api_doc": "",
@@ -27320,7 +28756,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Attaches one or more EC2 instances to the specified Auto Scaling group.",
         "docs": {
           "api_doc": "",
@@ -27334,7 +28773,9 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [
-          "autoscaling:TargetGroupARNs"
+          "autoscaling:TargetGroupARNs",
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
         ],
         "description": "Attaches one or more target groups to the specified Auto Scaling group.",
         "docs": {
@@ -27349,7 +28790,9 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [
-          "autoscaling:LoadBalancerNames"
+          "autoscaling:LoadBalancerNames",
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
         ],
         "description": "Attaches one or more load balancers to the specified Auto Scaling group.",
         "docs": {
@@ -27363,7 +28806,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes the specified scheduled actions.",
         "docs": {
           "api_doc": "",
@@ -27376,7 +28822,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Creates or updates multiple scheduled scaling actions for an Auto Scaling group.",
         "docs": {
           "api_doc": "",
@@ -27389,7 +28838,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Completes the lifecycle action for the specified token or instance with the specified result.",
         "docs": {
           "api_doc": "",
@@ -27412,7 +28864,9 @@
           "autoscaling:TargetGroupARNs",
           "autoscaling:VPCZoneIdentifiers",
           "aws:RequestTag/${TagKey}",
-          "aws:TagKeys"
+          "aws:TagKeys",
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
         ],
         "description": "Creates an Auto Scaling group with the specified name and attributes.",
         "docs": {
@@ -27446,7 +28900,9 @@
         "calculated_action_group": "Tagging",
         "condition_keys": [
           "aws:RequestTag/${TagKey}",
-          "aws:TagKeys"
+          "aws:TagKeys",
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
         ],
         "description": "Creates or updates tags for the specified Auto Scaling group.",
         "docs": {
@@ -27460,7 +28916,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes the specified Auto Scaling group.",
         "docs": {
           "api_doc": "",
@@ -27486,7 +28945,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes the specified lifecycle hook.",
         "docs": {
           "api_doc": "",
@@ -27499,7 +28961,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes the specified notification.",
         "docs": {
           "api_doc": "",
@@ -27512,7 +28977,10 @@
           "Permissions"
         ],
         "calculated_action_group": "Permissions",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes the specified Auto Scaling policy.",
         "docs": {
           "api_doc": "",
@@ -27525,7 +28993,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Deletes the specified scheduled action.",
         "docs": {
           "api_doc": "",
@@ -27541,7 +29012,9 @@
         "calculated_action_group": "Tagging",
         "condition_keys": [
           "aws:RequestTag/${TagKey}",
-          "aws:TagKeys"
+          "aws:TagKeys",
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
         ],
         "description": "Deletes the specified tags.",
         "docs": {
@@ -27753,7 +29226,7 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "Describes one or more scaling activities for the specified Auto Scaling group. ",
+        "description": "Describes one or more scaling activities for the specified Auto Scaling group.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -27824,7 +29297,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Removes one or more instances from the specified Auto Scaling group.",
         "docs": {
           "api_doc": "",
@@ -27838,7 +29314,9 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [
-          "autoscaling:TargetGroupARNs"
+          "autoscaling:TargetGroupARNs",
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
         ],
         "description": "Detaches one or more target groups from the specified Auto Scaling group.",
         "docs": {
@@ -27853,7 +29331,9 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [
-          "autoscaling:LoadBalancerNames"
+          "autoscaling:LoadBalancerNames",
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
         ],
         "description": "Removes one or more load balancers from the specified Auto Scaling group.",
         "docs": {
@@ -27867,7 +29347,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Disables monitoring of the specified metrics for the specified Auto Scaling group.",
         "docs": {
           "api_doc": "",
@@ -27880,7 +29363,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Enables monitoring of the specified metrics for the specified Auto Scaling group.",
         "docs": {
           "api_doc": "",
@@ -27893,7 +29379,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Moves the specified instances into Standby mode.",
         "docs": {
           "api_doc": "",
@@ -27906,7 +29395,10 @@
           "Permissions"
         ],
         "calculated_action_group": "Permissions",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Executes the specified policy.",
         "docs": {
           "api_doc": "",
@@ -27919,7 +29411,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Moves the specified instances out of Standby mode.",
         "docs": {
           "api_doc": "",
@@ -27932,7 +29427,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Creates or updates a lifecycle hook for the specified Auto Scaling Group.",
         "docs": {
           "api_doc": "",
@@ -27945,7 +29443,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Configures an Auto Scaling group to send notifications when specified events take place.",
         "docs": {
           "api_doc": "",
@@ -27958,7 +29459,10 @@
           "Permissions"
         ],
         "calculated_action_group": "Permissions",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Creates or updates a policy for an Auto Scaling group.",
         "docs": {
           "api_doc": "",
@@ -27973,7 +29477,9 @@
         "calculated_action_group": "Write",
         "condition_keys": [
           "autoscaling:MaxSize",
-          "autoscaling:MinSize"
+          "autoscaling:MinSize",
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
         ],
         "description": "Creates or updates a scheduled scaling action for an Auto Scaling group.",
         "docs": {
@@ -27987,7 +29493,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Records a heartbeat for the lifecycle action associated with the specified token or instance.",
         "docs": {
           "api_doc": "",
@@ -28000,7 +29509,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Resumes the specified suspended Auto Scaling processes, or all suspended process, for the specified Auto Scaling group.",
         "docs": {
           "api_doc": "",
@@ -28013,7 +29525,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Sets the size of the specified Auto Scaling group.",
         "docs": {
           "api_doc": "",
@@ -28026,7 +29541,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Sets the health status of the specified instance.",
         "docs": {
           "api_doc": "",
@@ -28039,7 +29557,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Updates the instance protection settings of the specified instances.",
         "docs": {
           "api_doc": "",
@@ -28052,7 +29573,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Suspends the specified Auto Scaling processes, or all processes, for the specified Auto Scaling group.",
         "docs": {
           "api_doc": "",
@@ -28065,7 +29589,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
+        ],
         "description": "Terminates the specified instance and optionally adjusts the desired group size.",
         "docs": {
           "api_doc": "",
@@ -28083,7 +29610,9 @@
           "autoscaling:LaunchConfigurationName",
           "autoscaling:MaxSize",
           "autoscaling:MinSize",
-          "autoscaling:VPCZoneIdentifiers"
+          "autoscaling:VPCZoneIdentifiers",
+          "autoscaling:ResourceTag/${TagKey}",
+          "aws:ResourceTag/${TagKey}"
         ],
         "description": "Updates the configuration for the specified Auto Scaling group.",
         "docs": {
@@ -28432,7 +29961,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "working-with-ei.html#ei-role-policy"
+          "doc_page_rel": ""
         }
       }
     },
@@ -28534,6 +30063,19 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/eks/latest/APIReference/API_ListUpdates.html"
+        }
+      },
+      "UpdateClusterConfig": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Update Amazon EKS cluster configurations (eg: API server endpoint access).",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateClusterConfig.html"
         }
       },
       "UpdateClusterVersion": {
@@ -28717,7 +30259,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Describes the Elastic Load Balancing resource limits for the AWS account. ",
+        "description": "Describes the Elastic Load Balancing resource limits for the AWS account.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -28731,7 +30273,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Describes the certificates for the specified secure listener. ",
+        "description": "Describes the certificates for the specified secure listener.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -28745,7 +30287,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Describes the specified listeners or the listeners for the specified Application Load Balancer. ",
+        "description": "Describes the specified listeners or the listeners for the specified Application Load Balancer.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -28787,7 +30329,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Describes the specified rules or the rules for the specified listener. ",
+        "description": "Describes the specified rules or the rules for the specified listener.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -28843,7 +30385,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Describes the specified target groups or all of your target groups. ",
+        "description": "Describes the specified target groups or all of your target groups.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -29001,7 +30543,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Associates the specified security groups with the specified load balancer. ",
+        "description": "Associates the specified security groups with the specified load balancer.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -29014,7 +30556,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Enables the Availability Zone for the specified subnets for the specified load balancer. ",
+        "description": "Enables the Availability Zone for the specified subnets for the specified load balancer.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -29031,7 +30573,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/"
+          "doc_page_rel": ""
         }
       }
     },
@@ -29097,7 +30639,9 @@
         ],
         "calculated_action_group": "Tagging",
         "condition_keys": [
-          "elasticmapreduce:RequestTag/${TagKey}"
+          "elasticmapreduce:RequestTag/${TagKey}",
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
         ],
         "description": "Grants permission to add tags to an Amazon EMR resource.",
         "docs": {
@@ -29126,13 +30670,15 @@
         ],
         "calculated_action_group": "Tagging",
         "condition_keys": [
-          "elasticmapreduce:RequestTag/${TagKey}"
+          "elasticmapreduce:RequestTag/${TagKey}",
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
         ],
         "description": "Grants permission to create an EMR notebook.",
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}emr-managed-notebooks-create.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/emr/latest/APIReference/emr-managed-notebooks-create.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-managed-notebooks-create.html"
         }
       },
       "CreateSecurityConfiguration": {
@@ -29158,7 +30704,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}emr-managed-notebooks.html#emr-managed-notebooks-deleting",
-          "doc_page_rel": "https://docs.aws.amazon.com/emr/latest/APIReference/emr-managed-notebooks.html#emr-managed-notebooks-deleting"
+          "doc_page_rel": "https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-managed-notebooks.html#emr-managed-notebooks-deleting"
         }
       },
       "DeleteSecurityConfiguration": {
@@ -29381,11 +30927,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Grants permission to launch the Jupyter notebook editor for an EMR notebook from within the console. ",
+        "description": "Grants permission to launch the Jupyter notebook editor for an EMR notebook from within the console.",
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}emr-managed-notebooks.html#emr-managed-notebooks-editor",
-          "doc_page_rel": "https://docs.aws.amazon.com/emr/latest/APIReference/emr-managed-notebooks.html#emr-managed-notebooks-editor"
+          "doc_page_rel": "https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-managed-notebooks.html#emr-managed-notebooks-editor"
         }
       },
       "PutAutoScalingPolicy": {
@@ -29420,7 +30966,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:TagKeys"
+        ],
         "description": "Grants permission to remove tags from an Amazon EMR resource.",
         "docs": {
           "api_doc": "",
@@ -29435,7 +30983,9 @@
         ],
         "calculated_action_group": "Tagging",
         "condition_keys": [
-          "elasticmapreduce:RequestTag/${TagKey}"
+          "elasticmapreduce:RequestTag/${TagKey}",
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
         ],
         "description": "Grants permission to create and launch a cluster (job flow).",
         "docs": {
@@ -29467,7 +31017,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}emr-managed-notebooks-working-with.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/emr/latest/APIReference/emr-managed-notebooks-working-with.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-managed-notebooks-working-with.html"
         }
       },
       "StopEditor": {
@@ -29476,11 +31026,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Grants permission to shut down an EMR notebook. ",
+        "description": "Grants permission to shut down an EMR notebook.",
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}emr-managed-notebooks.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/emr/latest/APIReference/emr-managed-notebooks.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-managed-notebooks.html"
         }
       },
       "TerminateJobFlows": {
@@ -29600,7 +31150,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "The CreateCacheSecurityGroup action creates a new cache security group. ",
+        "description": "The CreateCacheSecurityGroup action creates a new cache security group.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -30125,7 +31675,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to cancel in-progress environment configuration update or application version deployment.",
         "docs": {
           "api_doc": "",
@@ -30139,7 +31691,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Grants permission to add tags to an Elastic Beanstalk resource and to update tag values.",
         "docs": {
           "api_doc": "",
@@ -30152,7 +31707,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to apply a scheduled managed action immediately.",
         "docs": {
           "api_doc": "",
@@ -30179,7 +31736,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to create or update a group of environments, each running a separate component of a single application.",
         "docs": {
           "api_doc": "",
@@ -30192,7 +31751,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Grants permission to create a new application.",
         "docs": {
           "api_doc": "",
@@ -30205,7 +31767,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication",
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Grants permission to create an application version for an application.",
         "docs": {
           "api_doc": "",
@@ -30224,7 +31790,10 @@
           "elasticbeanstalk:FromConfigurationTemplate",
           "elasticbeanstalk:FromEnvironment",
           "elasticbeanstalk:FromPlatform",
-          "elasticbeanstalk:FromSolutionStack"
+          "elasticbeanstalk:FromSolutionStack",
+          "elasticbeanstalk:InApplication",
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
         ],
         "description": "Grants permission to create a configuration template.",
         "docs": {
@@ -30242,7 +31811,10 @@
           "elasticbeanstalk:FromApplicationVersion",
           "elasticbeanstalk:FromConfigurationTemplate",
           "elasticbeanstalk:FromPlatform",
-          "elasticbeanstalk:FromSolutionStack"
+          "elasticbeanstalk:FromSolutionStack",
+          "elasticbeanstalk:InApplication",
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
         ],
         "description": "Grants permission to launch an environment for an application.",
         "docs": {
@@ -30256,7 +31828,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Grants permission to create a new version of a custom platform.",
         "docs": {
           "api_doc": "",
@@ -30295,7 +31870,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to delete an application version from an application.",
         "docs": {
           "api_doc": "",
@@ -30308,7 +31885,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to delete a configuration template.",
         "docs": {
           "api_doc": "",
@@ -30321,7 +31900,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to delete the draft configuration associated with the running environment.",
         "docs": {
           "api_doc": "",
@@ -30363,7 +31944,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to retrieve a list of application versions stored in an AWS Elastic Beanstalk storage bucket.",
         "docs": {
           "api_doc": "",
@@ -30392,7 +31975,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to retrieve descriptions of environment configuration options.",
         "docs": {
           "api_doc": "",
@@ -30406,7 +31991,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to retrieve a description of the settings for a configuration set.",
         "docs": {
           "api_doc": "",
@@ -30434,7 +32021,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to retrieve a list of an environment's completed and failed managed actions.",
         "docs": {
           "api_doc": "",
@@ -30448,7 +32037,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to retrieve a list of an environment's upcoming and in-progress managed actions.",
         "docs": {
           "api_doc": "",
@@ -30462,7 +32053,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to retrieve a list of AWS resources for an environment.",
         "docs": {
           "api_doc": "",
@@ -30477,7 +32070,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to retrieve descriptions for existing environments.",
         "docs": {
           "api_doc": "",
@@ -30491,7 +32086,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to retrieve a list of event descriptions matching a set of criteria.",
         "docs": {
           "api_doc": "",
@@ -30576,7 +32173,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to delete and recreate all of the AWS resources for an environment and to force a restart.",
         "docs": {
           "api_doc": "",
@@ -30590,7 +32189,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:TagKeys"
+        ],
         "description": "Grants permission to remove tags from an Elastic Beanstalk resource.",
         "docs": {
           "api_doc": "",
@@ -30604,7 +32205,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to initiate a request to compile information of the deployed environment.",
         "docs": {
           "api_doc": "",
@@ -30617,7 +32220,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to request an environment to restart the application container server running on each Amazon EC2 instance.",
         "docs": {
           "api_doc": "",
@@ -30631,7 +32236,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to retrieve the compiled information from a RequestEnvironmentInfo request.",
         "docs": {
           "api_doc": "",
@@ -30645,7 +32252,8 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [
-          "elasticbeanstalk:FromEnvironment"
+          "elasticbeanstalk:FromEnvironment",
+          "elasticbeanstalk:InApplication"
         ],
         "description": "Grants permission to swap the CNAMEs of two environments.",
         "docs": {
@@ -30659,7 +32267,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to terminate an environment.",
         "docs": {
           "api_doc": "",
@@ -30698,7 +32308,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to update an application version with specified properties.",
         "docs": {
           "api_doc": "",
@@ -30717,7 +32329,8 @@
           "elasticbeanstalk:FromConfigurationTemplate",
           "elasticbeanstalk:FromEnvironment",
           "elasticbeanstalk:FromPlatform",
-          "elasticbeanstalk:FromSolutionStack"
+          "elasticbeanstalk:FromSolutionStack",
+          "elasticbeanstalk:InApplication"
         ],
         "description": "Grants permission to update a configuration template with specified properties or configuration option values.",
         "docs": {
@@ -30735,7 +32348,8 @@
           "elasticbeanstalk:FromApplicationVersion",
           "elasticbeanstalk:FromConfigurationTemplate",
           "elasticbeanstalk:FromPlatform",
-          "elasticbeanstalk:FromSolutionStack"
+          "elasticbeanstalk:FromSolutionStack",
+          "elasticbeanstalk:InApplication"
         ],
         "description": "Grants permission to update an environment.",
         "docs": {
@@ -30750,7 +32364,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "elasticbeanstalk:InApplication"
+        ],
         "description": "Grants permission to check the validity of a set of configuration settings for a configuration template or an environment.",
         "docs": {
           "api_doc": "",
@@ -30801,7 +32417,7 @@
           "aws:ResourceTag/${TagKey}",
           "ecr:ResourceTag/${TagKey}"
         ],
-        "description": "Deletes a list of specified images within a specified repository. ",
+        "description": "Deletes a list of specified images within a specified repository.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -30882,7 +32498,7 @@
           "aws:ResourceTag/${TagKey}",
           "ecr:ResourceTag/${TagKey}"
         ],
-        "description": "Deletes an existing image repository. ",
+        "description": "Deletes an existing image repository.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -30964,7 +32580,7 @@
           "aws:ResourceTag/${TagKey}",
           "ecr:ResourceTag/${TagKey}"
         ],
-        "description": "Retrieves the pre-signed Amazon S3 download URL corresponding to an image layer. ",
+        "description": "Retrieves the pre-signed Amazon S3 download URL corresponding to an image layer.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -31225,7 +32841,12 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ecs:cluster",
+          "ecs:task-definition",
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Runs and maintains a desired number of tasks from a specified task definition.",
         "docs": {
           "api_doc": "",
@@ -31238,7 +32859,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ecs:cluster",
+          "ecs:service",
+          "ecs:task-definition"
+        ],
         "description": "Creates a new Amazon ECS task set.",
         "docs": {
           "api_doc": "",
@@ -31292,7 +32917,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ecs:cluster"
+        ],
         "description": "Deletes a specified service within a cluster.",
         "docs": {
           "api_doc": "",
@@ -31305,7 +32932,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ecs:cluster",
+          "ecs:service"
+        ],
         "description": "Deletes the specified task set.",
         "docs": {
           "api_doc": "",
@@ -31375,7 +33005,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "ecs:cluster"
+        ],
         "description": "Describes the specified services running in your cluster.",
         "docs": {
           "api_doc": "",
@@ -31403,7 +33035,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "ecs:cluster",
+          "ecs:service"
+        ],
         "description": "Describes Amazon ECS task sets.",
         "docs": {
           "api_doc": "",
@@ -31507,7 +33142,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "ecs:cluster"
+        ],
         "description": "Lists the services that are running in a specified cluster.",
         "docs": {
           "api_doc": "",
@@ -31589,7 +33226,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}instance_IAM_role.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonECS/latest/APIReference/instance_IAM_role.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/instance_IAM_role.html"
         }
       },
       "PutAccountSetting": {
@@ -31824,7 +33461,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ecs:cluster",
+          "ecs:task-definition"
+        ],
         "description": "Modifies the desired count, deployment configuration, or task definition used in a service.",
         "docs": {
           "api_doc": "",
@@ -31837,7 +33477,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ecs:cluster"
+        ],
         "description": "Modifies the primary task set used in a service.",
         "docs": {
           "api_doc": "",
@@ -31850,7 +33492,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ecs:cluster",
+          "ecs:service"
+        ],
         "description": "Updates the specified task set.",
         "docs": {
           "api_doc": "",
@@ -32802,7 +34447,7 @@
         "condition_keys": [
           "aws:ResourceTag/${TagKey}"
         ],
-        "description": "Lists the tags for the specified delivery stream. ",
+        "description": "Lists the tags for the specified delivery stream.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -33156,7 +34801,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/freertos/latest/userguide/"
+          "doc_page_rel": ""
         }
       },
       "DeleteSoftwareConfiguration": {
@@ -33171,7 +34816,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/freertos/latest/userguide/"
+          "doc_page_rel": ""
         }
       },
       "DescribeHardwarePlatform": {
@@ -33185,7 +34830,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/freertos/latest/userguide/"
+          "doc_page_rel": ""
         }
       },
       "DescribeSoftwareConfiguration": {
@@ -33201,7 +34846,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/freertos/latest/userguide/"
+          "doc_page_rel": ""
         }
       },
       "GetSoftwareURL": {
@@ -33215,7 +34860,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/freertos/latest/userguide/"
+          "doc_page_rel": ""
         }
       },
       "GetSoftwareURLForConfiguration": {
@@ -33229,7 +34874,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/freertos/latest/userguide/"
+          "doc_page_rel": ""
         }
       },
       "ListFreeRTOSVersions": {
@@ -33244,7 +34889,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/freertos/latest/userguide/"
+          "doc_page_rel": ""
         }
       },
       "ListHardwarePlatforms": {
@@ -33259,7 +34904,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/freertos/latest/userguide/"
+          "doc_page_rel": ""
         }
       },
       "ListHardwareVendors": {
@@ -33274,7 +34919,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/freertos/latest/userguide/"
+          "doc_page_rel": ""
         }
       },
       "ListSoftwareConfigurations": {
@@ -33289,7 +34934,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/freertos/latest/userguide/"
+          "doc_page_rel": ""
         }
       },
       "UpdateSoftwareConfiguration": {
@@ -33304,7 +34949,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/freertos/latest/userguide/"
+          "doc_page_rel": ""
         }
       }
     },
@@ -34657,6 +36302,62 @@
           "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-BatchDeleteTable"
         }
       },
+      "BatchDeleteTableVersion": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to delete one or more versions of a table",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-DeleteTableVersion"
+        }
+      },
+      "BatchGetCrawlers": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve one or more crawlers",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-crawler-crawling.html#aws-glue-api-crawler-crawling-BatchGetCrawlers"
+        }
+      },
+      "BatchGetDevEndpoints": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve one or more development endpoints",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-dev-endpoint.html#aws-glue-api-dev-endpoint-BatchGetDevEndpoints"
+        }
+      },
+      "BatchGetJobs": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve one or more jobs",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-jobs-job.html#aws-glue-api-jobs-job-BatchGetJobs"
+        }
+      },
       "BatchGetPartition": {
         "aws_action_groups": [
           "ReadOnly",
@@ -34669,6 +36370,47 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-partitions.html#aws-glue-api-catalog-partitions-BatchGetPartition"
+        }
+      },
+      "BatchGetTriggers": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve one or more triggers",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-jobs-trigger.html#aws-glue-api-jobs-trigger-BatchGetTriggers"
+        }
+      },
+      "BatchGetWorkflows": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve one or more workflows",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-workflow.html#aws-glue-api-workflow-BatchGetWorkflows"
+        }
+      },
+      "BatchStopJobRun": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to stop one or more job runs for a job",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-jobs-runs.html#aws-glue-api-jobs-runs-BatchStopStartJobRun"
         }
       },
       "CreateClassifier": {
@@ -34827,6 +36569,19 @@
           "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-functions.html#aws-glue-api-catalog-functions-CreateUserDefinedFunction"
         }
       },
+      "CreateWorkflow": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to create a workflow",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-workflow.html#aws-glue-api-workflow-CreateWorkflow"
+        }
+      },
       "DeleteClassifier": {
         "aws_action_groups": [
           "ReadWrite"
@@ -34957,6 +36712,20 @@
           "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-DeleteTable"
         }
       },
+      "DeleteTableVersion": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to delete a version of a table",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-DeleteTableVersion"
+        }
+      },
       "DeleteTrigger": {
         "aws_action_groups": [
           "ReadWrite"
@@ -34981,6 +36750,19 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-functions.html#aws-glue-api-catalog-functions-DeleteUserDefinedFunction"
+        }
+      },
+      "DeleteWorkflow": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to delete a workflow",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-workflow.html#aws-glue-api-workflow-DeleteWorkflow"
         }
       },
       "GetCatalogImportStatus": {
@@ -35346,6 +37128,20 @@
           "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-GetTable"
         }
       },
+      "GetTableVersion": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve a version of a table",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-GetTableVersion"
+        }
+      },
       "GetTableVersions": {
         "aws_action_groups": [
           "ReadOnly",
@@ -35372,6 +37168,20 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-GetTables"
+        }
+      },
+      "GetTags": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve all tags associated with a resource",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-tags.html#aws-glue-api-tags-UntagResource"
         }
       },
       "GetTrigger": {
@@ -35430,6 +37240,62 @@
           "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-functions.html#aws-glue-api-catalog-functions-GetUserDefinedFunctions"
         }
       },
+      "GetWorkflow": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve a workflow",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-workflow.html#aws-glue-api-workflow-GetWorkflow"
+        }
+      },
+      "GetWorkflowRun": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve a workflow run",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-workflow.html#aws-glue-api-workflow-GetWorkflowRun"
+        }
+      },
+      "GetWorkflowRunProperties": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve workflow run properties",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-workflow.html#aws-glue-api-workflow-GetWorkflowRunProperties"
+        }
+      },
+      "GetWorkflowRuns": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve all runs of a workflow",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-workflow.html#aws-glue-api-workflow-GetWorkflowRuns"
+        }
+      },
       "ImportCatalogToGlue": {
         "aws_action_groups": [
           "ReadWrite"
@@ -35441,6 +37307,81 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-migration.html#aws-glue-api-catalog-migration-ImportCatalogToGlue"
+        }
+      },
+      "ListCrawlers": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve all crawlers",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-crawler-crawling.html#aws-glue-api-crawler-crawling-ListCrawlers"
+        }
+      },
+      "ListDevEndpoints": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve all development endpoints",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-dev-endpoint.html#aws-glue-api-dev-endpoint-ListDevEndpoints"
+        }
+      },
+      "ListJobs": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve all current jobs",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-jobs-job.html#aws-glue-api-jobs-job-ListJobs"
+        }
+      },
+      "ListTriggers": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve all triggers",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-jobs-trigger.html#aws-glue-api-jobs-trigger-ListTriggers"
+        }
+      },
+      "ListWorkflows": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve all workflows",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-workflow.html#aws-glue-api-workflow-ListWorkflows"
         }
       },
       "PutDataCatalogEncryptionSettings": {
@@ -35467,6 +37408,19 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-jobs-security.html#aws-glue-api-jobs-security-PutResourcePolicy"
+        }
+      },
+      "PutWorkflowRunProperties": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to update workflow run properties",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-workflow.html#aws-glue-api-workflow-PutWorkflowRunProperties"
         }
       },
       "ResetJobBookmark": {
@@ -35534,6 +37488,19 @@
           "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-jobs-trigger.html#aws-glue-api-jobs-trigger-StartTrigger"
         }
       },
+      "StartWorkflowRun": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to start running a workflow",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-workflow.html#aws-glue-api-workflow-StartWorkflowRun"
+        }
+      },
       "StopCrawler": {
         "aws_action_groups": [
           "ReadWrite"
@@ -35571,6 +37538,34 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-jobs-trigger.html#aws-glue-api-jobs-trigger-StopTrigger"
+        }
+      },
+      "TagResource": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to add tags to a resource",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-tags.html#aws-glue-api-tags-TagResource"
+        }
+      },
+      "UntagResource": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to remove tags associated with a resource",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-tags.html#aws-glue-api-tags-UntagResource"
         }
       },
       "UpdateClassifier": {
@@ -35701,6 +37696,19 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-functions.html#aws-glue-api-catalog-functions-UpdateUserDefinedFunction"
+        }
+      },
+      "UpdateWorkflow": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to update a workflow",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-workflow.html#aws-glue-api-workflow-UpdateWorkflow"
         }
       }
     },
@@ -37921,7 +39929,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Grants permission for an IAM user to create their own access key and secret access key",
+        "description": "Grants permission to create access key and secret access key for the specified IAM user",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -38497,6 +40505,22 @@
           "doc_page_rel": "https://docs.aws.amazon.com/IAM/latest/APIReference/API_GenerateCredentialReport.html"
         }
       },
+      "GenerateOrganizationsAccessReport": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [
+          "iam:OrganizationsPolicyId"
+        ],
+        "description": "Grants permission to generate an access report for an AWS Organizations entity",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/IAM/latest/APIReference/API_GenerateOrganizationsAccessReport.html"
+        }
+      },
       "GenerateServiceLastAccessedDetails": {
         "aws_action_groups": [
           "ReadOnly",
@@ -38679,6 +40703,20 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetOpenIDConnectProvider.html"
+        }
+      },
+      "GetOrganizationsAccessReport": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve an AWS Organizations access report",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetOrganizationsAccessReport.html"
         }
       },
       "GetPolicy": {
@@ -39281,7 +41319,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}id_roles_use_passrole.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/IAM/latest/APIReference/id_roles_use_passrole.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html"
         }
       },
       "PutGroupPolicy": {
@@ -40519,7 +42557,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}policy-actions.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/iot/latest/apireference/policy-actions.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot/latest/developerguide/policy-actions.html"
         }
       },
       "CreateAuthorizer": {
@@ -41045,7 +43083,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}policy-actions.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/iot/latest/apireference/policy-actions.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot/latest/developerguide/policy-actions.html"
         }
       },
       "DeleteThingType": {
@@ -41638,7 +43676,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}policy-actions.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/iot/latest/apireference/policy-actions.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot/latest/developerguide/policy-actions.html"
         }
       },
       "GetTopicRule": {
@@ -42289,7 +44327,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}policy-actions.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/iot/latest/apireference/policy-actions.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot/latest/developerguide/policy-actions.html"
         }
       },
       "Receive": {
@@ -42302,7 +44340,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}policy-actions.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/iot/latest/apireference/policy-actions.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot/latest/developerguide/policy-actions.html"
         }
       },
       "RegisterCACertificate": {
@@ -42541,7 +44579,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}policy-actions.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/iot/latest/apireference/policy-actions.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot/latest/developerguide/policy-actions.html"
         }
       },
       "TagResource": {
@@ -42865,7 +44903,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}policy-actions.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/iot/latest/apireference/policy-actions.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot/latest/developerguide/policy-actions.html"
         }
       },
       "ValidateSecurityProfileBehaviors": {
@@ -42923,7 +44961,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${DocHomeURL}iot-1-click/1.0/devices-apireference/claims-claimcode.html",
-          "doc_page_rel": "${DocHomeURL}iot-1-click/1.0/devices-apireference/claims-claimcode.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-1-click/1.0/devices-apireference/claims-claimcode.html"
         }
       },
       "CreatePlacement": {
@@ -42992,7 +45030,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${DocHomeURL}iot-1-click/1.0/devices-apireference/devices-deviceid.html",
-          "doc_page_rel": "${DocHomeURL}iot-1-click/1.0/devices-apireference/devices-deviceid.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-1-click/1.0/devices-apireference/devices-deviceid.html"
         }
       },
       "DescribePlacement": {
@@ -43050,7 +45088,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${DocHomeURL}iot-1-click/1.0/devices-apireference/devices-deviceid-finalize-claim.html",
-          "doc_page_rel": "${DocHomeURL}iot-1-click/1.0/devices-apireference/devices-deviceid-finalize-claim.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-1-click/1.0/devices-apireference/devices-deviceid-finalize-claim.html"
         }
       },
       "GetDeviceMethods": {
@@ -43064,7 +45102,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${DocHomeURL}iot-1-click/1.0/devices-apireference/devices-deviceid-methods.html",
-          "doc_page_rel": "${DocHomeURL}iot-1-click/1.0/devices-apireference/devices-deviceid-methods.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-1-click/1.0/devices-apireference/devices-deviceid-methods.html"
         }
       },
       "GetDevicesInPlacement": {
@@ -43092,7 +45130,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${DocHomeURL}iot-1-click/1.0/devices-apireference/devices-deviceid-initiate-claim.html",
-          "doc_page_rel": "${DocHomeURL}iot-1-click/1.0/devices-apireference/devices-deviceid-initiate-claim.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-1-click/1.0/devices-apireference/devices-deviceid-initiate-claim.html"
         }
       },
       "InvokeDeviceMethod": {
@@ -43105,7 +45143,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${DocHomeURL}iot-1-click/1.0/devices-apireference/devices-deviceid-methods.html",
-          "doc_page_rel": "${DocHomeURL}iot-1-click/1.0/devices-apireference/devices-deviceid-methods.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-1-click/1.0/devices-apireference/devices-deviceid-methods.html"
         }
       },
       "ListDeviceEvents": {
@@ -43119,7 +45157,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${DocHomeURL}iot-1-click/1.0/devices-apireference/devices-deviceid-events.html",
-          "doc_page_rel": "${DocHomeURL}iot-1-click/1.0/devices-apireference/devices-deviceid-events.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-1-click/1.0/devices-apireference/devices-deviceid-events.html"
         }
       },
       "ListDevices": {
@@ -43134,7 +45172,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${DocHomeURL}iot-1-click/1.0/devices-apireference/devices.html",
-          "doc_page_rel": "${DocHomeURL}iot-1-click/1.0/devices-apireference/devices.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-1-click/1.0/devices-apireference/devices.html"
         }
       },
       "ListPlacements": {
@@ -43208,7 +45246,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${DocHomeURL}iot-1-click/1.0/devices-apireference/devices-deviceid-unclaim.html",
-          "doc_page_rel": "${DocHomeURL}iot-1-click/1.0/devices-apireference/devices-deviceid-unclaim.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-1-click/1.0/devices-apireference/devices-deviceid-unclaim.html"
         }
       },
       "UntagResource": {
@@ -43236,7 +45274,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${DocHomeURL}iot-1-click/1.0/devices-apireference/devices-deviceid-state.html",
-          "doc_page_rel": "${DocHomeURL}iot-1-click/1.0/devices-apireference/devices-deviceid-state.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-1-click/1.0/devices-apireference/devices-deviceid-state.html"
         }
       },
       "UpdatePlacement": {
@@ -43817,7 +45855,20 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/developerguide/iotevents/latest/APIReference/API_BatchPutMessage.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_iotevents-data_BatchPutMessage.html"
+        }
+      },
+      "BatchUpdateDetector": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Update an detector within the AWS IoT Events system.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_iotevents-data_BatchUpdateDetector.html"
         }
       },
       "CreateDetectorModel": {
@@ -43825,12 +45876,15 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a detector model.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/developerguide/iotevents/latest/APIReference/API_CreateDetectorModel.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_CreateDetectorModel.html"
         }
       },
       "CreateInput": {
@@ -43838,12 +45892,15 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates an input.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/developerguide/iotevents/latest/APIReference/API_CreateInput.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_CreateInput.html"
         }
       },
       "DeleteDetectorModel": {
@@ -43856,7 +45913,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/developerguide/iotevents/latest/APIReference/API_DeleteDetectorModel.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_DeleteDetectorModel.html"
         }
       },
       "DeleteInput": {
@@ -43869,7 +45926,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/developerguide/iotevents/latest/APIReference/API_DeleteInput.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_DeleteInput.html"
         }
       },
       "DescribeDetector": {
@@ -43883,7 +45940,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/developerguide/iotevents/latest/APIReference/API_DescribeDetector.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_iotevents-data_DescribeDetector.html"
         }
       },
       "DescribeDetectorModel": {
@@ -43897,7 +45954,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/developerguide/iotevents/latest/APIReference/API_DescribeDetectorModel.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_DescribeDetectorModel.html"
         }
       },
       "DescribeInput": {
@@ -43911,7 +45968,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/developerguide/iotevents/latest/APIReference/API_DescribeInput.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_DescribeInput.html"
         }
       },
       "DescribeLoggingOptions": {
@@ -43925,7 +45982,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/developerguide/iotevents/latest/APIReference/API_DescribeLoggingOptions.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_DescribeLoggingOptions.html"
         }
       },
       "ListDetectorModelVersions": {
@@ -43940,7 +45997,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/developerguide/iotevents/latest/APIReference/API_ListDetectorModelVersions.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_ListDetectorModelVersions.html"
         }
       },
       "ListDetectorModels": {
@@ -43955,7 +46012,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/developerguide/iotevents/latest/APIReference/API_ListDetectorModels.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_ListDetectorModels.html"
         }
       },
       "ListDetectors": {
@@ -43972,7 +46029,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/developerguide/iotevents/latest/APIReference/API_ListDetectors.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_iotevents-data_ListDetectors.html"
         }
       },
       "ListInputs": {
@@ -43987,7 +46044,21 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_ListInputs.html"
+        }
+      },
+      "ListTagsForResource": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Lists the tags (metadata) which you have assigned to the resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_ListTagsForResource.html"
         }
       },
       "PutLoggingOptions": {
@@ -44000,7 +46071,40 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/developerguide/iotevents/latest/APIReference/API_PutLoggingOptions.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_PutLoggingOptions.html"
+        }
+      },
+      "TagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
+        "description": "Adds to or modifies the tags of the given resource. Tags are metadata which can be used to manage a resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_TagResource.html"
+        }
+      },
+      "UntagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:TagKeys"
+        ],
+        "description": "Removes the given tags (metadata) from the resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_UntagResource.html"
         }
       },
       "UpdateDetectorModel": {
@@ -44013,7 +46117,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/developerguide/iotevents/latest/APIReference/API_UpdateDetectorModel.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_UpdateDetectorModel.html"
         }
       },
       "UpdateInput": {
@@ -44026,7 +46130,20 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/developerguide/iotevents/latest/APIReference/API_UpdateInput.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_UpdateInput.html"
+        }
+      },
+      "UpdateInputRouting": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Updates input routing.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/iotevents/latest/apireference/API_UpdateInputRouting.html"
         }
       }
     },
@@ -44056,7 +46173,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_AssociateGatewaySink.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_AssociateGatewaySink.html"
         }
       },
       "AssociateGatewaySource": {
@@ -44069,7 +46186,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_AssociateGatewaySource.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_AssociateGatewaySource.html"
         }
       },
       "AssociateViewEntities": {
@@ -44082,7 +46199,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_AssociateViewEntities.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_AssociateViewEntities.html"
         }
       },
       "CreateAsset": {
@@ -44095,7 +46212,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_CreateAsset.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_CreateAsset.html"
         }
       },
       "CreateAssetTemplate": {
@@ -44108,7 +46225,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_CreateAssetTemplate.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_CreateAssetTemplate.html"
         }
       },
       "CreateGateway": {
@@ -44121,7 +46238,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_CreateGateway.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_CreateGateway.html"
         }
       },
       "CreateGroup": {
@@ -44134,7 +46251,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_CreateGroup.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_CreateGroup.html"
         }
       },
       "CreateMeasurementDataStore": {
@@ -44147,7 +46264,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_CreateMeasurementDataStore.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_CreateMeasurementDataStore.html"
         }
       },
       "CreateMetricType": {
@@ -44160,7 +46277,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_CreateMetricType.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_CreateMetricType.html"
         }
       },
       "CreateView": {
@@ -44173,7 +46290,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_CreateView.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_CreateView.html"
         }
       },
       "DeleteAsset": {
@@ -44186,7 +46303,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_DeleteAsset.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DeleteAsset.html"
         }
       },
       "DeleteAssetTemplate": {
@@ -44199,7 +46316,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_DeleteAssetTemplate.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DeleteAssetTemplate.html"
         }
       },
       "DeleteGateway": {
@@ -44212,7 +46329,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_DeleteGateway.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DeleteGateway.html"
         }
       },
       "DeleteGroup": {
@@ -44225,7 +46342,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_DeleteGroup.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DeleteGroup.html"
         }
       },
       "DeleteMeasurementDataStore": {
@@ -44238,7 +46355,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_DeleteMeasurementDataStore.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DeleteMeasurementDataStore.html"
         }
       },
       "DeleteMetricType": {
@@ -44251,7 +46368,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_DeleteMetricType.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DeleteMetricType.html"
         }
       },
       "DeleteView": {
@@ -44264,7 +46381,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_DeleteView.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DeleteView.html"
         }
       },
       "DeregisterViewEntities": {
@@ -44277,7 +46394,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_DeregisterViewEntities.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DeregisterViewEntities.html"
         }
       },
       "DescribeAssetTemplates": {
@@ -44291,7 +46408,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_DescribeAssetTemplates.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DescribeAssetTemplates.html"
         }
       },
       "DescribeAssets": {
@@ -44305,7 +46422,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_DescribeAssets.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DescribeAssets.html"
         }
       },
       "DescribeGateways": {
@@ -44319,7 +46436,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_DescribeGateways.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DescribeGateways.html"
         }
       },
       "DescribeGroups": {
@@ -44333,7 +46450,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_DescribeGroups.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DescribeGroups.html"
         }
       },
       "DescribeMeasurementDataStores": {
@@ -44347,7 +46464,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_DescribeMeasurementDataStores.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DescribeMeasurementDataStores.html"
         }
       },
       "DescribeMetricTypes": {
@@ -44361,7 +46478,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_DescribeMetricTypes.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DescribeMetricTypes.html"
         }
       },
       "DescribeViews": {
@@ -44375,7 +46492,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_DescribeViews.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DescribeViews.html"
         }
       },
       "DisassociateGatewaySink": {
@@ -44388,7 +46505,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_DisassociateGatewaySink.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DisassociateGatewaySink.html"
         }
       },
       "DisassociateGatewaySource": {
@@ -44401,7 +46518,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_DisassociateGatewaySource.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DisassociateGatewaySource.html"
         }
       },
       "DisassociateViewEntities": {
@@ -44414,7 +46531,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_DisassociateViewEntities.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_DisassociateViewEntities.html"
         }
       },
       "GetMeasurementData": {
@@ -44428,7 +46545,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_GetMeasurementData.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_GetMeasurementData.html"
         }
       },
       "GetMetricData": {
@@ -44442,7 +46559,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_GetMetricData.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_GetMetricData.html"
         }
       },
       "ListAssetTemplates": {
@@ -44457,7 +46574,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_ListAssetTemplates.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListAssetTemplates.html"
         }
       },
       "ListAssets": {
@@ -44472,7 +46589,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_ListAssets.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListAssets.html"
         }
       },
       "ListGateways": {
@@ -44487,7 +46604,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_ListGateways.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListGateways.html"
         }
       },
       "ListGroups": {
@@ -44502,7 +46619,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_ListGroups.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListGroups.html"
         }
       },
       "ListMeasurementDataStores": {
@@ -44517,7 +46634,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_ListMeasurementDataStores.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListMeasurementDataStores.html"
         }
       },
       "ListMeasurementDataStreams": {
@@ -44532,7 +46649,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_ListMeasurementDataStreams.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListMeasurementDataStreams.html"
         }
       },
       "ListMetricTypes": {
@@ -44547,7 +46664,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_ListMetricTypes.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListMetricTypes.html"
         }
       },
       "ListViewEntities": {
@@ -44562,7 +46679,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_ListViewEntities.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListViewEntities.html"
         }
       },
       "ListViews": {
@@ -44577,7 +46694,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_ListViews.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_ListViews.html"
         }
       },
       "RegisterViewEntities": {
@@ -44590,7 +46707,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_RegisterViewEntities.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_RegisterViewEntities.html"
         }
       },
       "UpdateAsset": {
@@ -44603,7 +46720,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_UpdateAsset.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_UpdateAsset.html"
         }
       },
       "UpdateAssetTemplate": {
@@ -44616,7 +46733,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_UpdateAssetTemplate.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_UpdateAssetTemplate.html"
         }
       },
       "UpdateGateway": {
@@ -44629,7 +46746,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_UpdateGateway.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_UpdateGateway.html"
         }
       },
       "UpdateGroup": {
@@ -44642,7 +46759,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_UpdateGroup.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_UpdateGroup.html"
         }
       },
       "UpdateMeasurementDataStore": {
@@ -44655,7 +46772,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_UpdateMeasurementDataStore.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_UpdateMeasurementDataStore.html"
         }
       },
       "UpdateView": {
@@ -44668,7 +46785,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/iotsitewise/latest/APIReference/API_UpdateView.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/iot-sitewise/latest/APIReference/API_UpdateView.html"
         }
       }
     },
@@ -45824,7 +47941,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates an application.",
         "docs": {
           "api_doc": "",
@@ -45994,6 +48114,20 @@
           "doc_page_rel": "https://docs.aws.amazon.com/kinesisanalytics/latest/apiv2/API_ListApplications.html"
         }
       },
+      "ListTagsForResource": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Fetch the tags associated with the application.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/kinesisanalytics/latest/apiv2/API_ListTagsForResource.html"
+        }
+      },
       "StartApplication": {
         "aws_action_groups": [
           "ReadWrite"
@@ -46018,6 +48152,39 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/kinesisanalytics/latest/apiv2/API_StopApplication.html"
+        }
+      },
+      "TagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
+        "description": "Add tags to the application.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/kinesisanalytics/latest/apiv2/API_TagResource.html"
+        }
+      },
+      "UntagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:TagKeys"
+        ],
+        "description": "Remove the specified tags from the application.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/kinesisanalytics/latest/apiv2/API_UntagResource.html"
         }
       },
       "UpdateApplication": {
@@ -46092,6 +48259,20 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_DescribeStream.html"
+        }
+      },
+      "GetDASHStreamingSessionURL": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Creates a URL for MPEG-DASH video streaming.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_GetDASHStreamingSessionURL.html"
         }
       },
       "GetDataEndpoint": {
@@ -46660,7 +48841,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/lambda/latest/dg/API_ListTagsForResource.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/lambda/latest/dg/API_ListTags.html"
         }
       },
       "ListVersionsByFunction": {
@@ -49339,12 +51520,28 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Grants permission to create a cluster.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/msk/1.0/apireference/clusters.html#CreateCluster"
+        }
+      },
+      "CreateConfiguration": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to create a configuration.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/msk/1.0/apireference/configurations.html#CreateConfiguration"
         }
       },
       "DeleteCluster": {
@@ -49374,6 +51571,48 @@
           "doc_page_rel": "https://docs.aws.amazon.com/msk/1.0/apireference/clusters-clusterarn.html#DescribeCluster"
         }
       },
+      "DescribeClusterOperation": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Returns a description of the cluster operation specified by the ARN.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/msk/1.0/apireference/operations-clusteroperationarn.html#DescribeClusterOperation"
+        }
+      },
+      "DescribeConfiguration": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to describe a configuration.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/msk/1.0/apireference/configurations-configurationarn.html#DescribeConfiguration"
+        }
+      },
+      "DescribeConfigurationRevision": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to describe a configuration revision.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/msk/1.0/apireference/configurations-configurationarn-revision.html#DescribeConfigurationRevision"
+        }
+      },
       "GetBootstrapBrokers": {
         "aws_action_groups": [
           "ReadWrite",
@@ -49386,6 +51625,20 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/msk/1.0/apireference/clusters-clusterarn-bootstrap-brokers.html#GetBootstrapBrokers"
+        }
+      },
+      "ListClusterOperations": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Returns a list of all the operations that have been performed on the specified MSK cluster.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/msk/1.0/apireference/clusters-clusterarn-operations.html#ListClusterOperations"
         }
       },
       "ListClusters": {
@@ -49403,6 +51656,21 @@
           "doc_page_rel": "https://docs.aws.amazon.com/msk/1.0/apireference/clusters.html#ListClusters"
         }
       },
+      "ListConfigurations": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Grants permission to return a list of all configurations in the current account.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/msk/1.0/apireference/configurations.html#CreateConfiguration"
+        }
+      },
       "ListNodes": {
         "aws_action_groups": [
           "ReadWrite",
@@ -49416,6 +51684,79 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/msk/1.0/apireference/clusters-clusterarn-nodes.html#ListNodes"
+        }
+      },
+      "ListTagsForResource": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to list tags of a MSK resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/msk/1.0/apireference/tags-resourcearn.html#ListTagsForResource"
+        }
+      },
+      "TagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
+        "description": "Grants permission to tag a MSK resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/msk/1.0/apireference/tags-resourcearn.html#TagResource"
+        }
+      },
+      "UntagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:TagKeys"
+        ],
+        "description": "Grants permission to remove tags from a MSK resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/msk/1.0/apireference/tags-resourcearn.html#UntagResource"
+        }
+      },
+      "UpdateBrokerStorage": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Updates the storage size of the broker nodes of the cluster",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/msk/1.0/apireference/clusters-clusterarn-nodes-storage.html#UpdateBrokerStorage"
+        }
+      },
+      "UpdateClusterConfiguration": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Update Kafka configuration running on a cluster.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/msk/1.0/apireference/clusters-clusterarn-configuration.html#UpdateClusterConfiguration"
         }
       }
     },
@@ -53186,7 +55527,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/neptune/latest/userguide/https://docs.aws.amazon.com/neptune/latest/userguide/get-started.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/neptune/latest/userguide/get-started.html"
         }
       }
     },
@@ -54967,6 +57308,21 @@
           "doc_page_rel": "https://docs.aws.amazon.com/organizations/latest/APIReference/API_ListRoots.html"
         }
       },
+      "ListTagsForResource": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Grants permission to list all tags for the specified resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/organizations/latest/APIReference/API_ListTagsForResource.html"
+        }
+      },
       "ListTargetsForPolicy": {
         "aws_action_groups": [
           "ListOnly",
@@ -55006,6 +57362,34 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/organizations/latest/APIReference/API_RemoveAccountFromOrganization.html"
+        }
+      },
+      "TagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [],
+        "description": "Grants permission to add one or more tags to the specified resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/organizations/latest/APIReference/API_TagResource.html"
+        }
+      },
+      "UntagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [],
+        "description": "Grants permission to remove one or more tags from the specified resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/organizations/latest/APIReference/API_UntagResource.html"
         }
       },
       "UpdateOrganizationalUnit": {
@@ -56542,6 +58926,142 @@
   },
   "Private Marketplace": {
     "actions": {
+      "AssociateProductsWithPrivateMarketplace": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Adds new approved products to the Private Marketplace. This action can be performed by any account in an AWS Organization, provided the user has permissions to do so, and the Organization's Service Control Policies allow it.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/marketplace/latest/buyerguide/private-marketplace.html"
+        }
+      },
+      "CreatePrivateMarketplace": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Creates a Private Marketplace for the individual account, or for the entire AWS Organization if one exists. This action can only be performed by the master account if using an AWS Organization.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/marketplace/latest/buyerguide/private-marketplace.html"
+        }
+      },
+      "CreatePrivateMarketplaceProfile": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Creates a Private Marketplace Profile that customizes the white label experience on the AWS Marketplace website for the individual account, or for the entire AWS Organization if one exists. This action can only be performed by the master account if using an AWS Organization.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/marketplace/latest/buyerguide/private-marketplace.html"
+        }
+      },
+      "DescribePrivateMarketplaceProducts": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Describes the status of requested products in the Private Marketplace for administrative purposes. This action can be performed by any account in an AWS Organization, provided the user has permissions to do so, and the Organization's Service Control Policies allow it.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/marketplace/latest/buyerguide/private-marketplace.html"
+        }
+      },
+      "DescribePrivateMarketplaceProfile": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Describes details about the Private Marketplace Profile for administrative purposes. This action can be performed by any account in an AWS Organization, provided the user has permissions to do so, and the Organization's Service Control Policies allow it.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/marketplace/latest/buyerguide/private-marketplace.html"
+        }
+      },
+      "DescribePrivateMarketplaceStatus": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Describes the status of the Private Marketplace for administrative purposes. This action can be performed by any account in an AWS Organization, provided the user has permissions to do so, and the Organization's Service Control Policies allow it.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/marketplace/latest/buyerguide/private-marketplace.html"
+        }
+      },
+      "DisassociateProductsFromPrivateMarketplace": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Removes approved products from the Private Marketplace. This action can be performed by any account in an AWS Organization, provided the user has permissions to do so, and the Organization's Service Control Policies allow it.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/marketplace/latest/buyerguide/private-marketplace.html"
+        }
+      },
+      "ListPrivateMarketplaceProducts": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Queryable list for the products and status of products in the Private Marketplace for administrative purposes. This action can be performed by any account in an AWS Organization, provided the user has permissions to do so, and the Organization's Service Control Policies allow it.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/marketplace/latest/buyerguide/private-marketplace.html"
+        }
+      },
+      "StartPrivateMarketplace": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Starts the Private Marketplace, enabling the customized AWS Marketplace experience, and enabling restrictions on the procurement of products based on what is available in the Private Marketplace. This action can be performed by any account in an AWS Organization, provided the user has permissions to do so, and the Organization's Service Control Policies allow it.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/marketplace/latest/buyerguide/private-marketplace.html"
+        }
+      },
+      "StopPrivateMarketplace": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Stops the Private Marketplace, disabling the customized AWS Marketplace experience and removing the Private Marketplace procurement restrictions on products. This action can be performed by any account in an AWS Organization, provided the user has permissions to do so, and the Organization's Service Control Policies allow it.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/marketplace/latest/buyerguide/private-marketplace.html"
+        }
+      },
       "Subscribe": {
         "aws_action_groups": [
           "ReadWrite"
@@ -56566,6 +59086,19 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/marketplace/latest/controlling-access/ControllingAccessToAWSMarketplaceSubscriptions.html#SummaryOfAWSMarketplaceSubscriptionsPermissions"
+        }
+      },
+      "UpdatePrivateMarketplaceProfile": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Updates the Private Marketplace Profile that customizes the white label experience on the AWS Marketplace website for the individual account, or for the entire AWS Organization if one exists. This action can be performed by any account in an AWS Organization, provided the user has permissions to do so, and the Organization's Service Control Policies allow it.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/marketplace/latest/buyerguide/private-marketplace.html"
         }
       },
       "ViewSubscriptions": {
@@ -56631,7 +59164,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "quicksight:UserName"
+        ],
         "description": "Add a QuickSight user to a QuickSight group.",
         "docs": {
           "api_doc": "",
@@ -56683,7 +59218,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "quicksight:UserName"
+        ],
         "description": "Remove a user from a group so that he/she is no longer a member of the group.",
         "docs": {
           "api_doc": "",
@@ -56724,7 +59261,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Return a QuickSight group\ufffd\ufffd\ufffds description and ARN.",
+        "description": "Return a QuickSight group\u00e2\u0080\u0099s description and ARN.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -56838,7 +59375,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "quicksight:IamArn",
+          "quicksight:SessionName"
+        ],
         "description": "Create a QuickSight user, whose identity is associated with the IAM identity/role specified in the request.",
         "docs": {
           "api_doc": "",
@@ -56946,7 +59486,12 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:DatabaseEngine",
+          "rds:DatabaseName",
+          "rds:Vpc",
+          "rds:cluster-tag"
+        ],
         "description": "Associates an Identity and Access Management (IAM) role from an Aurora DB cluster.",
         "docs": {
           "api_doc": "",
@@ -56972,7 +59517,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:es-tag"
+        ],
         "description": "Adds a source identifier to an existing RDS event notification subscription.",
         "docs": {
           "api_doc": "",
@@ -56986,7 +59533,17 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:db-tag",
+          "rds:req-tag",
+          "rds:es-tag",
+          "rds:og-tag",
+          "rds:pg-tag",
+          "rds:ri-tag",
+          "rds:secgrp-tag",
+          "rds:snapshot-tag",
+          "rds:subgrp-tag"
+        ],
         "description": "Adds metadata tags to an Amazon RDS resource.",
         "docs": {
           "api_doc": "",
@@ -56999,7 +59556,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:db-tag"
+        ],
         "description": "Applies a pending maintenance action to a resource.",
         "docs": {
           "api_doc": "",
@@ -57012,7 +59571,9 @@
           "Permissions"
         ],
         "calculated_action_group": "Permissions",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:secgrp-tag"
+        ],
         "description": "Enables ingress to a DBSecurityGroup using one of two forms of authorization.",
         "docs": {
           "api_doc": "",
@@ -57051,7 +59612,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-snapshot-tag"
+        ],
         "description": "Creates a snapshot of a DB cluster.",
         "docs": {
           "api_doc": "",
@@ -57064,7 +59627,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:pg-tag"
+        ],
         "description": "Copies the specified DB parameter group.",
         "docs": {
           "api_doc": "",
@@ -57077,7 +59642,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:snapshot-tag"
+        ],
         "description": "Copies the specified DB snapshot.",
         "docs": {
           "api_doc": "",
@@ -57090,7 +59657,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:og-tag"
+        ],
         "description": "Copies the specified option group.",
         "docs": {
           "api_doc": "",
@@ -57104,7 +59673,15 @@
           "Tagging"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:DatabaseEngine",
+          "rds:DatabaseName",
+          "rds:Vpc",
+          "rds:req-tag",
+          "rds:cluster-pg-tag",
+          "rds:og-tag",
+          "rds:subgrp-tag"
+        ],
         "description": "Creates a new Amazon Aurora DB cluster.",
         "docs": {
           "api_doc": "",
@@ -57117,7 +59694,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-tag",
+          "rds:EndpointType"
+        ],
         "description": "Creates a new custom endpoint and associates it with an Amazon Aurora DB cluster.",
         "docs": {
           "api_doc": "",
@@ -57131,7 +59711,9 @@
           "Tagging"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:req-tag"
+        ],
         "description": "Create a new DB cluster parameter group.",
         "docs": {
           "api_doc": "",
@@ -57145,7 +59727,10 @@
           "Tagging"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-tag",
+          "rds:req-tag"
+        ],
         "description": "Creates a snapshot of a DB cluster.",
         "docs": {
           "api_doc": "",
@@ -57159,7 +59744,21 @@
           "Tagging"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:DatabaseClass",
+          "rds:DatabaseEngine",
+          "rds:DatabaseName",
+          "rds:MultiAz",
+          "rds:Piops",
+          "rds:StorageSize",
+          "rds:StorageEncrypted",
+          "rds:Vpc",
+          "rds:req-tag",
+          "rds:og-tag",
+          "rds:pg-tag",
+          "rds:secgrp-tag",
+          "rds:subgrp-tag"
+        ],
         "description": "Creates a new DB instance.",
         "docs": {
           "api_doc": "",
@@ -57173,7 +59772,13 @@
           "Tagging"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:Piops",
+          "rds:DatabaseClass",
+          "rds:req-tag",
+          "rds:og-tag",
+          "rds:subgrp-tag"
+        ],
         "description": "Creates a DB instance that acts as a Read Replica of a source DB instance.",
         "docs": {
           "api_doc": "",
@@ -57187,7 +59792,9 @@
           "Tagging"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:req-tag"
+        ],
         "description": "Creates a new DB parameter group.",
         "docs": {
           "api_doc": "",
@@ -57201,7 +59808,9 @@
           "Tagging"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:req-tag"
+        ],
         "description": "Creates a new DB security group. DB security groups control access to a DB instance.",
         "docs": {
           "api_doc": "",
@@ -57215,7 +59824,10 @@
           "Tagging"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:db-tag",
+          "rds:req-tag"
+        ],
         "description": "Creates a DBSnapshot.",
         "docs": {
           "api_doc": "",
@@ -57229,7 +59841,9 @@
           "Tagging"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:req-tag"
+        ],
         "description": "Creates a new DB subnet group.",
         "docs": {
           "api_doc": "",
@@ -57243,7 +59857,9 @@
           "Tagging"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:req-tag"
+        ],
         "description": "Creates an RDS event notification subscription.",
         "docs": {
           "api_doc": "",
@@ -57256,7 +59872,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-tag"
+        ],
         "description": "Creates an Aurora global database spread across multiple regions.",
         "docs": {
           "api_doc": "",
@@ -57270,7 +59888,9 @@
           "Tagging"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:req-tag"
+        ],
         "description": "Creates a new option group.",
         "docs": {
           "api_doc": "",
@@ -57283,7 +59903,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-tag",
+          "rds:cluster-snapshot-tag"
+        ],
         "description": "The DeleteDBCluster action deletes a previously provisioned DB cluster.",
         "docs": {
           "api_doc": "",
@@ -57296,7 +59919,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:EndpointType"
+        ],
         "description": "Deletes a custom endpoint and removes it from an Amazon Aurora DB cluster.",
         "docs": {
           "api_doc": "",
@@ -57309,7 +59934,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-pg-tag"
+        ],
         "description": "Deletes a specified DB cluster parameter group.",
         "docs": {
           "api_doc": "",
@@ -57322,7 +59949,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-snapshot-tag"
+        ],
         "description": "Deletes a DB cluster snapshot.",
         "docs": {
           "api_doc": "",
@@ -57335,7 +59964,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:db-tag"
+        ],
         "description": "The DeleteDBInstance action deletes a previously provisioned DB instance.",
         "docs": {
           "api_doc": "",
@@ -57361,7 +59992,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:pg-tag"
+        ],
         "description": "Deletes a specified DBParameterGroup.",
         "docs": {
           "api_doc": "",
@@ -57374,7 +60007,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:secgrp-tag"
+        ],
         "description": "Deletes a DB security group.",
         "docs": {
           "api_doc": "",
@@ -57387,7 +60022,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:snapshot-tag"
+        ],
         "description": "Deletes a DBSnapshot.",
         "docs": {
           "api_doc": "",
@@ -57400,7 +60037,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:subgrp-tag"
+        ],
         "description": "Deletes a DB subnet group.",
         "docs": {
           "api_doc": "",
@@ -57413,7 +60052,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:es-tag"
+        ],
         "description": "Deletes an RDS event notification subscription.",
         "docs": {
           "api_doc": "",
@@ -57439,7 +60080,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:og-tag"
+        ],
         "description": "Deletes an existing option group.",
         "docs": {
           "api_doc": "",
@@ -57484,7 +60127,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-tag"
+        ],
         "description": "Returns information about backtracks for a DB cluster.",
         "docs": {
           "api_doc": "",
@@ -57514,7 +60159,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-pg-tag"
+        ],
         "description": "Returns a list of DBClusterParameterGroup descriptions.",
         "docs": {
           "api_doc": "",
@@ -57529,7 +60176,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-pg-tag"
+        ],
         "description": "Returns the detailed parameter list for a particular DB cluster parameter group.",
         "docs": {
           "api_doc": "",
@@ -57544,7 +60193,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-snapshot-tag"
+        ],
         "description": "Returns a list of DB cluster snapshot attribute names and values for a manual DB cluster snapshot.",
         "docs": {
           "api_doc": "",
@@ -57573,7 +60224,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-tag"
+        ],
         "description": "Returns information about provisioned Aurora DB clusters.",
         "docs": {
           "api_doc": "",
@@ -57588,7 +60241,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:pg-tag"
+        ],
         "description": "Returns a list of the available DB engines.",
         "docs": {
           "api_doc": "",
@@ -57633,7 +60288,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:db-tag"
+        ],
         "description": "Returns a list of DB log files for the DB instance.",
         "docs": {
           "api_doc": "",
@@ -57648,7 +60305,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:pg-tag"
+        ],
         "description": "Returns a list of DBParameterGroup descriptions.",
         "docs": {
           "api_doc": "",
@@ -57663,7 +60322,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:pg-tag"
+        ],
         "description": "Returns the detailed parameter list for a particular DB parameter group.",
         "docs": {
           "api_doc": "",
@@ -57678,7 +60339,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:secgrp-tag"
+        ],
         "description": "Returns a list of DBSecurityGroup descriptions.",
         "docs": {
           "api_doc": "",
@@ -57693,7 +60356,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:snapshot-tag"
+        ],
         "description": "Returns a list of DB snapshot attribute names and values for a manual DB snapshot.",
         "docs": {
           "api_doc": "",
@@ -57708,7 +60373,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:db-tag",
+          "rds:snapshot-tag"
+        ],
         "description": "Returns information about DB snapshots.",
         "docs": {
           "api_doc": "",
@@ -57723,7 +60391,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:subgrp-tag"
+        ],
         "description": "Returns a list of DBSubnetGroup descriptions.",
         "docs": {
           "api_doc": "",
@@ -57783,7 +60453,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:es-tag"
+        ],
         "description": "Lists all the subscription descriptions for a customer account.",
         "docs": {
           "api_doc": "",
@@ -57798,7 +60470,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:es-tag"
+        ],
         "description": "Returns events related to DB instances, DB security groups, DB snapshots, and DB parameter groups for the past 14 days.",
         "docs": {
           "api_doc": "",
@@ -57828,7 +60502,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:og-tag"
+        ],
         "description": "Describes all available options.",
         "docs": {
           "api_doc": "",
@@ -57843,7 +60519,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:og-tag"
+        ],
         "description": "Describes the available option groups.",
         "docs": {
           "api_doc": "",
@@ -57873,7 +60551,16 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:DatabaseClass",
+          "rds:DatabaseEngine",
+          "rds:DatabaseName",
+          "rds:MultiAz",
+          "rds:Piops",
+          "rds:StorageSize",
+          "rds:Vpc",
+          "rds:db-tag"
+        ],
         "description": "Returns a list of resources (for example, DB instances) that have at least one pending maintenance action.",
         "docs": {
           "api_doc": "",
@@ -57888,7 +60575,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:DatabaseClass",
+          "rds:MultiAz",
+          "rds:ri-tag"
+        ],
         "description": "Returns information about reserved DB instances for this account, or about a specified reserved DB instance.",
         "docs": {
           "api_doc": "",
@@ -57903,7 +60594,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:db-tag"
+        ],
         "description": "Lists available reserved DB instance offerings.",
         "docs": {
           "api_doc": "",
@@ -57933,7 +60626,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:db-tag"
+        ],
         "description": "Lists available modifications you can make to your DB instance",
         "docs": {
           "api_doc": "",
@@ -57952,7 +60647,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}RESTReference.html#RESTReference.DownloadCompleteDBLogFile",
-          "doc_page_rel": "https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/RESTReference.html#RESTReference.DownloadCompleteDBLogFile"
+          "doc_page_rel": "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/RESTReference.html#RESTReference.DownloadCompleteDBLogFile"
         }
       },
       "DownloadDBLogFilePortion": {
@@ -57961,7 +60656,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:db-tag"
+        ],
         "description": "Downloads all or a portion of the specified log file, up to 1 MB in size.",
         "docs": {
           "api_doc": "",
@@ -57974,7 +60671,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-tag"
+        ],
         "description": "Forces a failover for a DB cluster.",
         "docs": {
           "api_doc": "",
@@ -57988,7 +60687,16 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:db-tag",
+          "rds:es-tag",
+          "rds:og-tag",
+          "rds:pg-tag",
+          "rds:ri-tag",
+          "rds:secgrp-tag",
+          "rds:snapshot-tag",
+          "rds:subgrp-tag"
+        ],
         "description": "Lists all tags on an Amazon RDS resource.",
         "docs": {
           "api_doc": "",
@@ -58001,7 +60709,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-tag"
+        ],
         "description": "Modify current cluster capacity for an Amazon Aurora Severless DB cluster.",
         "docs": {
           "api_doc": "",
@@ -58014,7 +60724,12 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:Vpc",
+          "rds:cluster-tag",
+          "rds:cluster-pg-tag",
+          "rds:og-tag"
+        ],
         "description": "Modify a setting for an Amazon Aurora DB cluster.",
         "docs": {
           "api_doc": "",
@@ -58027,7 +60742,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:EndpointType"
+        ],
         "description": "Modifies the properties of an endpoint in an Amazon Aurora DB cluster.",
         "docs": {
           "api_doc": "",
@@ -58040,7 +60757,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-pg-tag"
+        ],
         "description": "Modifies the parameters of a DB cluster parameter group.",
         "docs": {
           "api_doc": "",
@@ -58053,7 +60772,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-snapshot-tag"
+        ],
         "description": "Adds an attribute and values to, or removes an attribute and values from, a manual DB cluster snapshot.",
         "docs": {
           "api_doc": "",
@@ -58066,7 +60787,17 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:DatabaseClass",
+          "rds:MultiAz",
+          "rds:Piops",
+          "rds:StorageSize",
+          "rds:Vpc",
+          "rds:db-tag",
+          "rds:og-tag",
+          "rds:pg-tag",
+          "rds:secgrp-tag"
+        ],
         "description": "Modify settings for a DB instance.",
         "docs": {
           "api_doc": "",
@@ -58079,7 +60810,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:pg-tag"
+        ],
         "description": "Modifies the parameters of a DB parameter group.",
         "docs": {
           "api_doc": "",
@@ -58092,7 +60825,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:snapshot-tag"
+        ],
         "description": "Updates a manual DB snapshot, which can be encrypted or not encrypted, with a new engine version.",
         "docs": {
           "api_doc": "",
@@ -58105,7 +60840,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:snapshot-tag"
+        ],
         "description": "Adds an attribute and values to, or removes an attribute and values from, a manual DB snapshot.",
         "docs": {
           "api_doc": "",
@@ -58118,7 +60855,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:subgrp-tag"
+        ],
         "description": "Modifies an existing DB subnet group.",
         "docs": {
           "api_doc": "",
@@ -58131,7 +60870,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:es-tag"
+        ],
         "description": "Modifies an existing RDS event notification subscription.",
         "docs": {
           "api_doc": "",
@@ -58157,7 +60898,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:og-tag"
+        ],
         "description": "Modifies an existing option group.",
         "docs": {
           "api_doc": "",
@@ -58170,7 +60913,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:db-tag"
+        ],
         "description": "Promotes a Read Replica DB instance to a standalone DB instance.",
         "docs": {
           "api_doc": "",
@@ -58183,7 +60928,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-tag"
+        ],
         "description": "Promotes a Read Replica DB cluster to a standalone DB cluster.",
         "docs": {
           "api_doc": "",
@@ -58209,7 +60956,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:db-tag"
+        ],
         "description": "Rebooting a DB instance restarts the database engine service.",
         "docs": {
           "api_doc": "",
@@ -58222,7 +60971,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-tag"
+        ],
         "description": "Detaches an Aurora secondary cluster from an Aurora global database cluster.",
         "docs": {
           "api_doc": "",
@@ -58235,7 +60986,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-tag"
+        ],
         "description": "Disassociates an AWS Identity and Access Management (IAM) role from an Amazon Aurora DB cluster.",
         "docs": {
           "api_doc": "",
@@ -58261,7 +61014,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:es-tag"
+        ],
         "description": "Removes a source identifier from an existing RDS event notification subscription.",
         "docs": {
           "api_doc": "",
@@ -58275,7 +61030,17 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:db-tag",
+          "rds:req-tag",
+          "rds:es-tag",
+          "rds:og-tag",
+          "rds:pg-tag",
+          "rds:ri-tag",
+          "rds:secgrp-tag",
+          "rds:snapshot-tag",
+          "rds:subgrp-tag"
+        ],
         "description": "Removes metadata tags from an Amazon RDS resource.",
         "docs": {
           "api_doc": "",
@@ -58288,7 +61053,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-pg-tag"
+        ],
         "description": "Modifies the parameters of a DB cluster parameter group to the default value.",
         "docs": {
           "api_doc": "",
@@ -58301,7 +61068,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:pg-tag"
+        ],
         "description": "Modifies the parameters of a DB parameter group to the engine/system default value.",
         "docs": {
           "api_doc": "",
@@ -58314,7 +61083,12 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:DatabaseEngine",
+          "rds:DatabaseName",
+          "rds:Vpc",
+          "rds:req-tag"
+        ],
         "description": "Creates an Amazon Aurora DB cluster from data stored in an Amazon S3 bucket.",
         "docs": {
           "api_doc": "",
@@ -58327,7 +61101,14 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:DatabaseEngine",
+          "rds:DatabaseName",
+          "rds:Vpc",
+          "rds:req-tag",
+          "rds:cluster-snapshot-tag",
+          "rds:og-tag"
+        ],
         "description": "Creates a new DB cluster from a DB cluster snapshot.",
         "docs": {
           "api_doc": "",
@@ -58340,7 +61121,12 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:Vpc",
+          "rds:req-tag",
+          "rds:og-tag",
+          "rds:subgrp-tag"
+        ],
         "description": "Restores a DB cluster to an arbitrary point in time.",
         "docs": {
           "api_doc": "",
@@ -58353,7 +61139,18 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:DatabaseClass",
+          "rds:DatabaseEngine",
+          "rds:DatabaseName",
+          "rds:MultiAz",
+          "rds:Piops",
+          "rds:Vpc",
+          "rds:req-tag",
+          "rds:og-tag",
+          "rds:snapshot-tag",
+          "rds:subgrp-tag"
+        ],
         "description": "Creates a new DB instance from a DB snapshot.",
         "docs": {
           "api_doc": "",
@@ -58366,7 +61163,15 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:DatabaseClass",
+          "rds:DatabaseEngine",
+          "rds:DatabaseName",
+          "rds:MultiAz",
+          "rds:Piops",
+          "rds:Vpc",
+          "rds:req-tag"
+        ],
         "description": "Creates a new DB instance from an Amazon S3 bucket.",
         "docs": {
           "api_doc": "",
@@ -58379,7 +61184,18 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:DatabaseClass",
+          "rds:DatabaseEngine",
+          "rds:DatabaseName",
+          "rds:MultiAz",
+          "rds:Piops",
+          "rds:Vpc",
+          "rds:req-tag",
+          "rds:og-tag",
+          "rds:snapshot-tag",
+          "rds:subgrp-tag"
+        ],
         "description": "Restores a DB instance to an arbitrary point in time.",
         "docs": {
           "api_doc": "",
@@ -58392,7 +61208,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:secgrp-tag"
+        ],
         "description": "Revokes ingress from a DBSecurityGroup for previously authorized IP ranges or EC2 or VPC Security Groups.",
         "docs": {
           "api_doc": "",
@@ -58405,7 +61223,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-tag"
+        ],
         "description": "Starts the DB cluster.",
         "docs": {
           "api_doc": "",
@@ -58418,7 +61238,16 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:DatabaseClass",
+          "rds:DatabaseEngine",
+          "rds:DatabaseName",
+          "rds:MultiAz",
+          "rds:Piops",
+          "rds:StorageSize",
+          "rds:Vpc",
+          "rds:db-tag"
+        ],
         "description": "Starts the DB instance.",
         "docs": {
           "api_doc": "",
@@ -58431,7 +61260,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:cluster-tag"
+        ],
         "description": "Stops the DB cluster.",
         "docs": {
           "api_doc": "",
@@ -58444,7 +61275,16 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "rds:DatabaseClass",
+          "rds:DatabaseEngine",
+          "rds:DatabaseName",
+          "rds:MultiAz",
+          "rds:Piops",
+          "rds:StorageSize",
+          "rds:Vpc",
+          "rds:db-tag"
+        ],
         "description": "Stops the DB instance.",
         "docs": {
           "api_doc": "",
@@ -58557,7 +61397,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}mgmt/redshift-policy-resources.resource-permissions.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/redshift/latest/APIReference/mgmt/redshift-policy-resources.resource-permissions.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/redshift/latest/mgmt/redshift-policy-resources.resource-permissions.html"
         }
       },
       "CancelResize": {
@@ -59794,7 +62634,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}mgmt/redshift-policy-resources.resource-permissions.html",
-          "doc_page_rel": "https://docs.aws.amazon.com/redshift/latest/APIReference/mgmt/redshift-policy-resources.resource-permissions.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/redshift/latest/mgmt/redshift-policy-resources.resource-permissions.html"
         }
       }
     },
@@ -60299,7 +63139,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ram:ShareOwnerAccountId"
+        ],
         "description": "Accept the specified resource share invitation",
         "docs": {
           "api_doc": "",
@@ -60312,7 +63154,13 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ram:AllowsExternalPrincipals",
+          "ram:Principal",
+          "ram:RequestedResourceType",
+          "ram:ResourceArn",
+          "ram:ResourceShareName"
+        ],
         "description": "Associates resource(s) and/or principal(s) to a resource share",
         "docs": {
           "api_doc": "",
@@ -60327,7 +63175,11 @@
         "calculated_action_group": "Write",
         "condition_keys": [
           "aws:RequestTag/${TagKey}",
-          "aws:TagKeys"
+          "aws:TagKeys",
+          "ram:Principal",
+          "ram:RequestedResourceType",
+          "ram:ResourceArn",
+          "ram:AllowsExternalPrincipals"
         ],
         "description": "Create resource share with provided resource(s) and/or principal(s)",
         "docs": {
@@ -60341,7 +63193,13 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ram:AllowsExternalPrincipals",
+          "ram:Principal",
+          "ram:RequestedResourceType",
+          "ram:ResourceArn",
+          "ram:ResourceShareName"
+        ],
         "description": "Delete resource share",
         "docs": {
           "api_doc": "",
@@ -60354,7 +63212,13 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ram:AllowsExternalPrincipals",
+          "ram:Principal",
+          "ram:RequestedResourceType",
+          "ram:ResourceArn",
+          "ram:ResourceShareName"
+        ],
         "description": "Disassociates resource(s) and/or principal(s) from a resource share",
         "docs": {
           "api_doc": "",
@@ -60395,7 +63259,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "ram:ResourceShareName"
+        ],
         "description": "Get a set of resource share associations from a provided list or with a specified status of the specified type",
         "docs": {
           "api_doc": "",
@@ -60409,8 +63275,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
-        "description": "Get resource share invitations by the specified invitation arn or those for the resource share ",
+        "condition_keys": [
+          "ram:ShareOwnerAccountId"
+        ],
+        "description": "Get resource share invitations by the specified invitation arn or those for the resource share",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -60423,12 +63291,28 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Read",
-        "condition_keys": [],
+        "condition_keys": [
+          "ram:ResourceShareName"
+        ],
         "description": "Get a set of resource shares from a provided list or with a specified status",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/ram/latest/APIReference/API_GetResourceShares.html"
+        }
+      },
+      "ListPendingInvitationResources": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Lists the resources in a resource share that is shared with you but that the invitation is still pending for",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/ram/latest/APIReference/API_ListPendingInvitationResources.html"
         }
       },
       "ListPrincipals": {
@@ -60438,7 +63322,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "ram:Principal"
+        ],
         "description": "Retrieve list of principals for a specified resource",
         "docs": {
           "api_doc": "",
@@ -60453,7 +63339,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "List",
-        "condition_keys": [],
+        "condition_keys": [
+          "ram:ResourceArn"
+        ],
         "description": "Retrieve list of resources for a specified principal",
         "docs": {
           "api_doc": "",
@@ -60466,7 +63354,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ram:ShareOwnerAccountId"
+        ],
         "description": "Reject the specified resource share invitation",
         "docs": {
           "api_doc": "",
@@ -60510,7 +63400,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ram:AllowsExternalPrincipals",
+          "ram:ResourceShareName"
+        ],
         "description": "Update attributes of the resource share",
         "docs": {
           "api_doc": "",
@@ -60628,7 +63521,10 @@
           "Tagging"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a group with a specified name, description, and resource query.",
         "docs": {
           "api_doc": "",
@@ -60742,7 +63638,10 @@
           "Tagging"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Tags a specified resource group",
         "docs": {
           "api_doc": "",
@@ -60756,7 +63655,9 @@
           "Tagging"
         ],
         "calculated_action_group": "Tagging",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:TagKeys"
+        ],
         "description": "Removes tags associated with a specified resource group",
         "docs": {
           "api_doc": "",
@@ -60821,13 +63722,26 @@
           "doc_page_rel": "https://docs.aws.amazon.com/robomaker/latest/API_Operations.htmlAPI_BatchDescribeSimulationJob.html"
         }
       },
+      "CancelDeploymentJob": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Cancel a deployment job",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/robomaker/latest/API_Operations.htmlAPI_CancelDeploymentJob.html"
+        }
+      },
       "CancelSimulationJob": {
         "aws_action_groups": [
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "End a simulation job",
+        "description": "Cancel a simulation job",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -60839,7 +63753,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:TagKeys",
+          "aws:RequestTag/${TagKey}"
+        ],
         "description": "Create a deployment job",
         "docs": {
           "api_doc": "",
@@ -60852,8 +63769,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
-        "description": "Create a fleet that represents a logical group of robots running the same robot application",
+        "condition_keys": [
+          "aws:TagKeys",
+          "aws:RequestTag/${TagKey}"
+        ],
+        "description": "Create a deployment fleet that represents a logical group of robots running the same robot application",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -60865,7 +63785,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:TagKeys",
+          "aws:RequestTag/${TagKey}"
+        ],
         "description": "Create a robot that can be registered to a fleet",
         "docs": {
           "api_doc": "",
@@ -60878,7 +63801,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:TagKeys",
+          "aws:RequestTag/${TagKey}"
+        ],
         "description": "Create a robot application",
         "docs": {
           "api_doc": "",
@@ -60904,8 +63830,11 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
-        "description": "Create a robot application",
+        "condition_keys": [
+          "aws:TagKeys",
+          "aws:RequestTag/${TagKey}"
+        ],
+        "description": "Create a simulation application",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -60918,7 +63847,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Create a snapshot of a robot application",
+        "description": "Create a snapshot of a simulation application",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -60930,12 +63859,28 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:TagKeys",
+          "aws:RequestTag/${TagKey}"
+        ],
         "description": "Create a simulation job",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/robomaker/latest/API_Operations.htmlAPI_CreateSimulationJob.html"
+        }
+      },
+      "DeleteFleet": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Delete a deployment fleet",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/robomaker/latest/API_Operations.htmlAPI_DeleteFleet.html"
         }
       },
       "DeleteRobot": {
@@ -60970,7 +63915,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Delete a robot application",
+        "description": "Delete a simulation application",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -61011,7 +63956,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Describe a fleet",
+        "description": "Describe a deployment fleet",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -61053,7 +63998,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Describe a robot application",
+        "description": "Describe a simulation application",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -61142,7 +64087,7 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "List robot applications",
+        "description": "List simulation applications",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -61162,6 +64107,21 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/robomaker/latest/API_Operations.htmlAPI_ListSimulationJobs.html"
+        }
+      },
+      "ListTagsForResource": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "List tags for a RoboMaker resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/robomaker/latest/API_Operations.htmlAPI_ListTagsForResource.html"
         }
       },
       "RegisterRobot": {
@@ -61203,6 +64163,37 @@
           "doc_page_rel": "https://docs.aws.amazon.com/robomaker/latest/API_Operations.htmlAPI_SyncDeploymentJob.html"
         }
       },
+      "TagResource": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "aws:TagKeys",
+          "aws:RequestTag/${TagKey}"
+        ],
+        "description": "Add tags to a RoboMaker resource",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/robomaker/latest/API_Operations.htmlAPI_TagResource.html"
+        }
+      },
+      "UntagResource": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "aws:TagKeys"
+        ],
+        "description": "Remove tags from a RoboMaker resource",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/robomaker/latest/API_Operations.htmlAPI_UntagResource.html"
+        }
+      },
       "UpdateRobotApplication": {
         "aws_action_groups": [
           "ReadWrite"
@@ -61222,7 +64213,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Update a robot application",
+        "description": "Update a simulation application",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -61839,7 +64830,7 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "Grants permission to list the reusable delegation sets that are associated with the current AWS account. ",
+        "description": "Grants permission to list the reusable delegation sets that are associated with the current AWS account.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -62051,7 +65042,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53resolver_AssociateResolverEndpointIpAddress"
+          "doc_page_rel": "https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53resolver_AssociateResolverEndpointIpAddress.html"
         }
       },
       "AssociateResolverRule": {
@@ -62732,6 +65723,26 @@
           "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUT.html"
         }
       },
+      "CreateJob": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "s3:authtype",
+          "s3:signatureage",
+          "s3:signatureversion",
+          "s3:x-amz-content-sha256",
+          "s3:RequestJobPriority",
+          "s3:RequestJobOperation"
+        ],
+        "description": "Creates a new Amazon S3 Batch Operations job.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTAccountPOSTCreateJob.html"
+        }
+      },
       "DeleteBucket": {
         "aws_action_groups": [
           "ReadWrite"
@@ -62862,6 +65873,25 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETEtagging.html"
+        }
+      },
+      "DescribeJob": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [
+          "s3:authtype",
+          "s3:signatureage",
+          "s3:signatureversion",
+          "s3:x-amz-content-sha256"
+        ],
+        "description": "Retrieves the configuration parameters and status for an Amazon S3 batch operations job.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTAccountGETDescribeJob.html"
         }
       },
       "GetAccelerateConfiguration": {
@@ -63009,6 +66039,23 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETnotification.html"
+        }
+      },
+      "GetBucketObjectLockConfiguration": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "s3:authtype",
+          "s3:signatureage",
+          "s3:signatureversion"
+        ],
+        "description": "GET Object Lock configuration for a specific bucket",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETObjectLockConfiguration.html"
         }
       },
       "GetBucketPolicy": {
@@ -63258,6 +66305,42 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGETacl.html"
+        }
+      },
+      "GetObjectLegalHold": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "s3:authtype",
+          "s3:signatureage",
+          "s3:signatureversion",
+          "s3:x-amz-content-sha256"
+        ],
+        "description": "GET Object Legal Hold for a specific object",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGETLegalHold.html"
+        }
+      },
+      "GetObjectRetention": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "s3:authtype",
+          "s3:signatureage",
+          "s3:signatureversion",
+          "s3:x-amz-content-sha256"
+        ],
+        "description": "GET Object Legal Hold for a specific object",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGETRetention.html"
         }
       },
       "GetObjectTagging": {
@@ -63539,6 +66622,25 @@
           "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETVersion.html"
         }
       },
+      "ListJobs": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [
+          "s3:authtype",
+          "s3:signatureage",
+          "s3:signatureversion",
+          "s3:x-amz-content-sha256"
+        ],
+        "description": "Lists current jobs and jobs that have ended recently.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTAccountGETListJobs.html"
+        }
+      },
       "ListMultipartUploadParts": {
         "aws_action_groups": [
           "ReadOnly",
@@ -63706,6 +66808,23 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTnotification.html"
+        }
+      },
+      "PutBucketObjectLockConfiguration": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "s3:authtype",
+          "s3:signatureage",
+          "s3:signatureversion"
+        ],
+        "description": "PUT Object Lock configuration on a specific bucket",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTObjectLockConfiguration.html"
         }
       },
       "PutBucketPolicy": {
@@ -63912,7 +67031,11 @@
           "s3:x-amz-server-side-encryption",
           "s3:x-amz-server-side-encryption-aws-kms-key-id",
           "s3:x-amz-storage-class",
-          "s3:x-amz-website-redirect-location"
+          "s3:x-amz-website-redirect-location",
+          "s3:object-lock-mode",
+          "s3:object-lock-retain-until-date",
+          "s3:object-lock-remaining-retention-days",
+          "s3:object-lock-legal-hold"
         ],
         "description": "Adds an object to a bucket.",
         "docs": {
@@ -63945,6 +67068,46 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUTacl.html"
+        }
+      },
+      "PutObjectLegalHold": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "s3:authtype",
+          "s3:signatureage",
+          "s3:signatureversion",
+          "s3:x-amz-content-sha256",
+          "s3:object-lock-legal-hold"
+        ],
+        "description": "PUT Object Legal Hold on a specific object",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUTLegalHold.html"
+        }
+      },
+      "PutObjectRetention": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "s3:authtype",
+          "s3:signatureage",
+          "s3:signatureversion",
+          "s3:x-amz-content-sha256",
+          "s3:object-lock-mode",
+          "s3:object-lock-retain-until-date",
+          "s3:object-lock-remaining-retention-days"
+        ],
+        "description": "PUT Object Retention on a specific object",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUTRetention.html"
         }
       },
       "PutObjectTagging": {
@@ -64110,6 +67273,48 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOSTrestore.html"
+        }
+      },
+      "UpdateJobPriority": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "s3:authtype",
+          "s3:signatureage",
+          "s3:signatureversion",
+          "s3:x-amz-content-sha256",
+          "s3:RequestJobPriority",
+          "s3:ExistingJobPriority",
+          "s3:ExistingJobOperation"
+        ],
+        "description": "Updates an existing job's priority.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTAccountPOSTUpdateJobPriority.html"
+        }
+      },
+      "UpdateJobStatus": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [
+          "s3:authtype",
+          "s3:signatureage",
+          "s3:signatureversion",
+          "s3:x-amz-content-sha256",
+          "s3:ExistingJobPriority",
+          "s3:ExistingJobOperation",
+          "s3:JobSuspendedCause"
+        ],
+        "description": "Updates the status for the specified job.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTAccountPOSTUpdateJobStatus.html"
         }
       }
     },
@@ -65093,7 +68298,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Verifies an email address.  This action causes a confirmation email message to be sent to the specified address. This action is throttled at one request per second",
+        "description": "Verifies an email address. This action causes a confirmation email message to be sent to the specified address. This action is throttled at one request per second",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -65379,6 +68584,20 @@
           "doc_page_rel": "https://docs.aws.amazon.com/sns/latest/api/API_ListSubscriptionsByTopic.html"
         }
       },
+      "ListTagsForResource": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "List all tags added to the specified Amazon SNS topic.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/sns/latest/api/API_ListTagsForResource.html"
+        }
+      },
       "ListTopics": {
         "aws_action_groups": [
           "ListOnly",
@@ -65514,6 +68733,23 @@
           "doc_page_rel": "https://docs.aws.amazon.com/sns/latest/api/API_Subscribe.html"
         }
       },
+      "TagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
+        "description": "Add tags to the specified Amazon SNS topic.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/sns/latest/api/API_TagResource.html"
+        }
+      },
       "Unsubscribe": {
         "aws_action_groups": [
           "ReadWrite"
@@ -65525,6 +68761,23 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/sns/latest/api/API_Unsubscribe.html"
+        }
+      },
+      "UntagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
+        "description": "Remove tags from the specified Amazon SNS topic.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/sns/latest/api/API_UntagResource.html"
         }
       }
     },
@@ -66946,7 +70199,7 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "Lists groups for a user from the directory that AWS SSO provides by default ",
+        "description": "Lists groups for a user from the directory that AWS SSO provides by default",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -67120,7 +70373,17 @@
           "<web-identity-provider>:aud",
           "<web-identity-provider>:oaud",
           "<web-identity-provider>:sub",
-          "aws:FederatedProvider"
+          "aws:FederatedProvider",
+          "cognito-identity.amazonaws.com:amr",
+          "cognito-identity.amazonaws.com:aud",
+          "cognito-identity.amazonaws.com:sub",
+          "www.amazon.com:app_id",
+          "www.amazon.com:user_id",
+          "graph.facebook.com:app_id",
+          "graph.facebook.com:id",
+          "accounts.google.com:aud",
+          "accounts.google.com:oaud",
+          "accounts.google.com:sub"
         ],
         "description": "Returns a set of temporary security credentials for users who have been authenticated in a mobile or web application with a web identity provider",
         "docs": {
@@ -67140,6 +70403,20 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/STS/latest/APIReference/API_DecodeAuthorizationMessage.html"
+        }
+      },
+      "GetAccessKeyInfo": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Returns details about the access key id passed as a parameter to the request.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/STS/latest/APIReference/API_GetAccessKeyInfo.html"
         }
       },
       "GetCallerIdentity": {
@@ -67405,7 +70682,8 @@
         "calculated_action_group": "Read",
         "condition_keys": [
           " swf:workflowType.name",
-          "swf:workflowType.version"
+          "swf:workflowType.version",
+          "swf:workflowType.name"
         ],
         "description": "Returns information about the specified workflow type.",
         "docs": {
@@ -68976,7 +72254,7 @@
           "aws:TagKeys",
           "sagemaker:ResourceTag/${TagKey}"
         ],
-        "description": "Stops a transform job.  When Amazon SageMaker receives a StopTransformJob request, the status of the job changes to Stopping.  After Amazon SageMaker stops the job, the status is set to Stopped",
+        "description": "Stops a transform job. When Amazon SageMaker receives a StopTransformJob request, the status of the job changes to Stopping. After Amazon SageMaker stops the job, the status is set to Stopped",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -69447,7 +72725,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/accept-invitation.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_AcceptInvitation.html"
         }
       },
       "BatchDisableStandards": {
@@ -69460,7 +72738,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/batch-disable-standards.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_BatchDisableStandards.html"
         }
       },
       "BatchEnableStandards": {
@@ -69473,7 +72751,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/batch-enable-standards.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_BatchEnableStandards.html"
         }
       },
       "BatchImportFindings": {
@@ -69488,7 +72766,20 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/batch-import-findings.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_BatchImportFindings.html"
+        }
+      },
+      "CreateActionTarget": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to create custom actions using the API. You can use custom actions on findings and insights in Security Hub to send them.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_CreateActionTarget.html"
         }
       },
       "CreateInsight": {
@@ -69501,7 +72792,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/create-insight.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_CreateInsight.html"
         }
       },
       "CreateMembers": {
@@ -69514,7 +72805,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/create-members.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_CreateMembers.html"
         }
       },
       "DeclineInvitations": {
@@ -69527,7 +72818,20 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/decline-invitations.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_DeclineInvitations.html"
+        }
+      },
+      "DeleteActionTarget": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to delete custom actions using the API.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_DeleteActionTarget.html"
         }
       },
       "DeleteInsight": {
@@ -69540,7 +72844,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/delete-insights.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_DeleteInsight.html"
         }
       },
       "DeleteInvitations": {
@@ -69553,7 +72857,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/delete-invitations.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_DeleteInvitations.html"
         }
       },
       "DeleteMembers": {
@@ -69566,7 +72870,49 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/delete-members.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_DeleteMembers.html"
+        }
+      },
+      "DescribeActionTargets": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve a list of custom actions using the API.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_DescribeActionTargets.html"
+        }
+      },
+      "DescribeHub": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve information about the hub resource in your account using the API.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_DescribeHub.html"
+        }
+      },
+      "DescribeProducts": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Returns information about the products available that you can subscribe to.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_DescribeProducts.html"
         }
       },
       "DisableImportFindingsForProduct": {
@@ -69579,7 +72925,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/disable-import-findings-for-product.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_DisableImportFindingsForProduct.html"
         }
       },
       "DisableSecurityHub": {
@@ -69592,7 +72938,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/disable-security-hub.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_DisableSecurityHub.html"
         }
       },
       "DisassociateFromMasterAccount": {
@@ -69605,7 +72951,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/disassociate-from-master-account.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_DisassociateFromMasterAccount.html"
         }
       },
       "DisassociateMembers": {
@@ -69618,7 +72964,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/disassociate-members.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_DisassociateMembers.html"
         }
       },
       "EnableImportFindingsForProduct": {
@@ -69631,7 +72977,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/enable-import-findings-for-product.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_EnableImportFindingsForProduct.html"
         }
       },
       "EnableSecurityHub": {
@@ -69639,12 +72985,15 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Enables the AWS Security Hub service.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/enable-security-hub.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_EnableSecurityHub.html"
         }
       },
       "GetEnabledStandards": {
@@ -69659,7 +73008,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/get-enabled-standards.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_GetEnabledStandards.html"
         }
       },
       "GetFindings": {
@@ -69673,7 +73022,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/get-findings.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_GetFindings.html"
         }
       },
       "GetInsightResults": {
@@ -69687,7 +73036,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/get-insight-results.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_GetInsightResults.html"
         }
       },
       "GetInsights": {
@@ -69702,7 +73051,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/get-insights.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_GetInsights.html"
         }
       },
       "GetInvitationsCount": {
@@ -69716,7 +73065,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/get-invitations-count.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_GetInvitationsCount.html"
         }
       },
       "GetMasterAccount": {
@@ -69730,7 +73079,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/get-master-account.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_GetMasterAccount.html"
         }
       },
       "GetMembers": {
@@ -69744,7 +73093,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/get-members.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_GetMembers.html"
         }
       },
       "InviteMembers": {
@@ -69757,7 +73106,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/invite-members.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_InviteMembers.html"
         }
       },
       "ListEnabledProductsForImport": {
@@ -69772,7 +73121,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/list-enabled-products-for-import.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_ListEnabledProductsForImport.html"
         }
       },
       "ListInvitations": {
@@ -69787,7 +73136,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/list-invitations.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_ListInvitations.html"
         }
       },
       "ListMembers": {
@@ -69802,7 +73151,48 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/list-members.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_ListMembers.html"
+        }
+      },
+      "ListTagsForResource": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Grants permission to list of tags associated with a resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_ListTagsForResource.html"
+        }
+      },
+      "TagResource": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to add tags to a resource using the API.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_TagResource.html"
+        }
+      },
+      "UntagResource": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to remove tags from a resource using the API.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_UntagResource.html"
         }
       },
       "UpdateFindings": {
@@ -69815,7 +73205,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/update-findings.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_UpdateFindings.html"
         }
       },
       "UpdateInsight": {
@@ -69828,7 +73218,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/latest/ug/update-insights.html"
+          "doc_page_rel": "https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_UpdateInsight.html"
         }
       }
     },
@@ -70460,6 +73850,19 @@
           "doc_page_rel": "https://docs.aws.amazon.com/servicecatalog/latest/dg/API_AcceptPortfolioShare.html"
         }
       },
+      "AssociateBudgetWithResource": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Associates a budget with a resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/servicecatalog/latest/dg/API_AssociateBudgetWithResource.html"
+        }
+      },
       "AssociatePrincipalWithPortfolio": {
         "aws_action_groups": [
           "ReadWrite"
@@ -70540,10 +73943,9 @@
       },
       "CopyProduct": {
         "aws_action_groups": [
-          "ReadWrite",
-          "Tagging"
+          "ReadWrite"
         ],
-        "calculated_action_group": "Tagging",
+        "calculated_action_group": "Write",
         "condition_keys": [],
         "description": "Copies the specified source product to the specified target product or a new product.",
         "docs": {
@@ -70567,10 +73969,9 @@
       },
       "CreatePortfolio": {
         "aws_action_groups": [
-          "ReadWrite",
-          "Tagging"
+          "ReadWrite"
         ],
-        "calculated_action_group": "Tagging",
+        "calculated_action_group": "Write",
         "condition_keys": [],
         "description": "Creates a portfolio",
         "docs": {
@@ -70594,10 +73995,9 @@
       },
       "CreateProduct": {
         "aws_action_groups": [
-          "ReadWrite",
-          "Tagging"
+          "ReadWrite"
         ],
-        "calculated_action_group": "Tagging",
+        "calculated_action_group": "Write",
         "condition_keys": [],
         "description": "Creates a product and that product's first provisioning artifact",
         "docs": {
@@ -70608,10 +74008,9 @@
       },
       "CreateProvisionedProductPlan": {
         "aws_action_groups": [
-          "ReadWrite",
-          "Tagging"
+          "ReadWrite"
         ],
-        "calculated_action_group": "Tagging",
+        "calculated_action_group": "Write",
         "condition_keys": [],
         "description": "Adds a new provisioned product plan",
         "docs": {
@@ -70949,6 +74348,20 @@
           "doc_page_rel": "https://docs.aws.amazon.com/servicecatalog/latest/dg/API_DescribeServiceAction.html"
         }
       },
+      "DescribeServiceActionExecutionParameters": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Gets the default parameters if you executed the specified Service Action on the specified Provisioned Product.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/servicecatalog/latest/dg/API_DescribeServiceActionExecutionParameters.html"
+        }
+      },
       "DescribeTagOption": {
         "aws_action_groups": [
           "ReadOnly",
@@ -70976,13 +74389,26 @@
           "doc_page_rel": "https://docs.aws.amazon.com/servicecatalog/latest/dg/API_DisableAWSOrganizationsAccess.html"
         }
       },
+      "DisassociateBudgetFromResource": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Disassociates a budget from a resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/servicecatalog/latest/dg/API_DisassociateBudgetFromResource.html"
+        }
+      },
       "DisassociatePrincipalFromPortfolio": {
         "aws_action_groups": [
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Disassociates an IAM principal from a portfolio",
+        "description": "Disassociates an IAM principal from a portfolio.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -71043,10 +74469,9 @@
       },
       "ExecuteProvisionedProductPlan": {
         "aws_action_groups": [
-          "ReadWrite",
-          "Tagging"
+          "ReadWrite"
         ],
-        "calculated_action_group": "Tagging",
+        "calculated_action_group": "Write",
         "condition_keys": [],
         "description": "Executes a provisioned product plan",
         "docs": {
@@ -71057,10 +74482,9 @@
       },
       "ExecuteProvisionedProductServiceAction": {
         "aws_action_groups": [
-          "ReadWrite",
-          "Tagging"
+          "ReadWrite"
         ],
-        "calculated_action_group": "Tagging",
+        "calculated_action_group": "Write",
         "condition_keys": [],
         "description": "Executes a provisioned product plan",
         "docs": {
@@ -71096,6 +74520,21 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/servicecatalog/latest/dg/API_ListAcceptedPortfolioShares.html"
+        }
+      },
+      "ListBudgetsForResource": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Lists all the budgets associated to a resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/servicecatalog/latest/dg/API_ListBudgetsForResource.html"
         }
       },
       "ListConstraintsForPortfolio": {
@@ -71312,6 +74751,21 @@
           "doc_page_rel": "https://docs.aws.amazon.com/servicecatalog/latest/dg/API_ListServiceActionsForProvisioningArtifact.html"
         }
       },
+      "ListStackInstancesForProvisionedProduct": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Lists account, region and status of each stack instances that are associated with a CFN_STACKSET type provisioned product",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/servicecatalog/latest/dg/API_ListStackInstancesForProvisionedProduct.html"
+        }
+      },
       "ListTagOptions": {
         "aws_action_groups": [
           "ListOnly",
@@ -71329,10 +74783,9 @@
       },
       "ProvisionProduct": {
         "aws_action_groups": [
-          "ReadWrite",
-          "Tagging"
+          "ReadWrite"
         ],
-        "calculated_action_group": "Tagging",
+        "calculated_action_group": "Write",
         "condition_keys": [],
         "description": "Provisions a product with a specified provisioning artifact and launch parameters",
         "docs": {
@@ -71454,10 +74907,9 @@
       },
       "UpdatePortfolio": {
         "aws_action_groups": [
-          "ReadWrite",
-          "Tagging"
+          "ReadWrite"
         ],
-        "calculated_action_group": "Tagging",
+        "calculated_action_group": "Write",
         "condition_keys": [],
         "description": "Updates the metadata fields and/or tags of an existing portfolio",
         "docs": {
@@ -71468,10 +74920,9 @@
       },
       "UpdateProduct": {
         "aws_action_groups": [
-          "ReadWrite",
-          "Tagging"
+          "ReadWrite"
         ],
-        "calculated_action_group": "Tagging",
+        "calculated_action_group": "Write",
         "condition_keys": [],
         "description": "Updates the metadata fields and/or tags of an existing product",
         "docs": {
@@ -71495,6 +74946,19 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/servicecatalog/latest/dg/API_UpdateProvisionedProduct.html"
+        }
+      },
+      "UpdateProvisionedProductProperties": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Updates the properties of an existing provisioned product",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/servicecatalog/latest/dg/API_UpdateProvisionedProductProperties.html"
         }
       },
       "UpdateProvisioningArtifact": {
@@ -73220,7 +76684,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Returns a description of specified virtual tapes in the virtual tape shelf (VTS). ",
+        "description": "Returns a description of specified virtual tapes in the virtual tape shelf (VTS).",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -73791,7 +77255,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}sumerian-permissions.html",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/sumerian/latest/userguide/sumerian-permissions.html"
         }
       },
       "ViewRelease": {
@@ -73805,7 +77269,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "${ConceptsDocRoot}sumerian-permissions.html",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/sumerian/latest/userguide/sumerian-permissions.html"
         }
       }
     },
@@ -74062,6 +77526,19 @@
           "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_CancelCommand.html"
         }
       },
+      "CancelMaintenanceWindowExecution": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Attempts to cancel the execution specified by the WindowExecution ID.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_CancelMaintenanceWindowExecution.html"
+        }
+      },
       "CreateActivation": {
         "aws_action_groups": [
           "ReadWrite"
@@ -74106,7 +77583,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates an SSM document.",
         "docs": {
           "api_doc": "",
@@ -74125,6 +77605,19 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_CreateMaintenanceWindow.html"
+        }
+      },
+      "CreateOpsItem": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Create a new OpsItem",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_CreateOpsItem.html"
         }
       },
       "CreatePatchBaseline": {
@@ -74190,6 +77683,19 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DeleteDocument.html"
+        }
+      },
+      "DeleteInventory": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Deletes a custom inventory type or the data associated with a custom inventory type.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DeleteInventory.html"
         }
       },
       "DeleteMaintenanceWindow": {
@@ -74263,7 +77769,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Removes the server or virtual machine from the list of registered servers.",
+        "description": "Enables the user to remove on-premises managed instances from the list of managed instances.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -74432,7 +77938,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/"
+          "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html"
         }
       },
       "DescribeDocumentPermission": {
@@ -74554,11 +78060,25 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Describes one or more your instances.",
+        "description": "Enables user's Amazon EC2 console to render managed instances' nodes",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/"
+          "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html"
+        }
+      },
+      "DescribeInventoryDeletions": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Describes a specific delete inventory operation.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DescribeInventoryDeletions.html"
         }
       },
       "DescribeMaintenanceWindowExecutionTaskInvocations": {
@@ -74606,6 +78126,21 @@
           "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/PI_DescribeMaintenanceWindowExecutions.html"
         }
       },
+      "DescribeMaintenanceWindowSchedule": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Describe the upcoming executions of one or more of your maintenance windows.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DescribeMaintenanceWindowSchedule.html"
+        }
+      },
       "DescribeMaintenanceWindowTargets": {
         "aws_action_groups": [
           "ListOnly",
@@ -74649,6 +78184,35 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DescribeMaintenanceWindows.html"
+        }
+      },
+      "DescribeMaintenanceWindowsForTarget": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Describe the maintenance windows to which your target belongs.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DescribeMaintenanceWindowsForTarget.html"
+        }
+      },
+      "DescribeOpsItems": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Returns a list of OpsItem based on different search criteria",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DescribeOpsItems.html"
         }
       },
       "DescribeParameters": {
@@ -74921,6 +78485,34 @@
           "doc_page_rel": ""
         }
       },
+      "GetOpsItem": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Returns details of an OpsItem",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetOpsItem.html"
+        }
+      },
+      "GetOpsSummary": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "View a summary of OpsItems based on specified filters and aggregators. Filter is used to scope down the returned OpsItems. Aggregator is used to return counts of OpsItems.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetOpsSummary.html"
+        }
+      },
       "GetParameter": {
         "aws_action_groups": [
           "ReadOnly",
@@ -75003,6 +78595,19 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetPatchBaselineForPatchGroup.html"
+        }
+      },
+      "LabelParameterVersion": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Attaches labels to a specific version of an existing parameter.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_LabelParameterVersion.html"
         }
       },
       "ListAssociationVersions": {
@@ -75255,7 +78860,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Add a parameter to the system.",
         "docs": {
           "api_doc": "",
@@ -75360,7 +78968,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ssm:resourceTag/tag-key"
+        ],
         "description": "Executes commands on one or more remote instances.",
         "docs": {
           "api_doc": "",
@@ -75399,7 +79009,9 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "ssm:SessionDocumentAccessCheck"
+        ],
         "description": "Start a connection to an instance using SSM Session Manager.",
         "docs": {
           "api_doc": "",
@@ -75504,11 +79116,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Updates the status of the SSM document associated with the specified instance.",
+        "description": "Enables user's SSM Agents to call the Systems Manager service in the cloud to provide heartbeat information.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html"
         }
       },
       "UpdateMaintenanceWindow": {
@@ -75561,6 +79173,19 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_UpdateManagedInstanceRole.html"
+        }
+      },
+      "UpdateOpsItem": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Edit or change an OpsItem",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_UpdateOpsItem.html"
         }
       },
       "UpdatePatchBaseline": {
@@ -76203,13 +79828,40 @@
   },
   "Trusted Advisor": {
     "actions": {
-      "DescribeCheckItems": {
+      "DescribeAccount": {
         "aws_action_groups": [
-          "ListOnly",
           "ReadOnly",
           "ReadWrite"
         ],
-        "calculated_action_group": "List",
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "View support plan and various TA preferences.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": ""
+        }
+      },
+      "DescribeAccountAccess": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Resolve whether Account has disabled Trusted Advisor",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": ""
+        }
+      },
+      "DescribeCheckItems": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
         "condition_keys": [],
         "description": "View details for the check items",
         "docs": {
@@ -76220,11 +79872,10 @@
       },
       "DescribeCheckRefreshStatuses": {
         "aws_action_groups": [
-          "ListOnly",
           "ReadOnly",
           "ReadWrite"
         ],
-        "calculated_action_group": "List",
+        "calculated_action_group": "Read",
         "condition_keys": [],
         "description": "Describe check refresh statuses",
         "docs": {
@@ -76235,11 +79886,10 @@
       },
       "DescribeCheckSummaries": {
         "aws_action_groups": [
-          "ListOnly",
           "ReadOnly",
           "ReadWrite"
         ],
-        "calculated_action_group": "List",
+        "calculated_action_group": "Read",
         "condition_keys": [],
         "description": "Describes the check's summaries",
         "docs": {
@@ -76248,13 +79898,26 @@
           "doc_page_rel": ""
         }
       },
-      "DescribeNotificationPreferences": {
+      "DescribeChecks": {
         "aws_action_groups": [
-          "ListOnly",
           "ReadOnly",
           "ReadWrite"
         ],
-        "calculated_action_group": "List",
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "List valid Trusted Advisor checks and details.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": ""
+        }
+      },
+      "DescribeNotificationPreferences": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
         "condition_keys": [],
         "description": "Describes the notification preferences for the account",
         "docs": {
@@ -76302,13 +79965,26 @@
           "doc_page_rel": ""
         }
       },
+      "SetAccountAccess": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Toggle whether TrustedAdvisor is enabled/disabled for the account",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": ""
+        }
+      },
       "UpdateNotificationPreferences": {
         "aws_action_groups": [
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Update notification preferences ",
+        "description": "Update notification preferences",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -76376,7 +80052,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a RateBasedRule, which contains a RateLimit specifying the maximum number of requests that AWS WAF allows from a specified IP address in a five-minute period.",
         "docs": {
           "api_doc": "",
@@ -76415,7 +80094,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a Rule, which contains the IPSet objects, ByteMatchSet objects, and other predicates that identify the requests that you want to block.",
         "docs": {
           "api_doc": "",
@@ -76428,7 +80110,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a RuleGroup. A rule group is a collection of predefined rules that you add to a WebACL.",
         "docs": {
           "api_doc": "",
@@ -76467,7 +80152,10 @@
           "Permissions"
         ],
         "calculated_action_group": "Permissions",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a WebACL, which contains the Rules that identify the CloudFront web requests that you want to allow, block, or count.",
         "docs": {
           "api_doc": "",
@@ -77117,6 +80805,20 @@
           "doc_page_rel": "https://docs.aws.amazon.com/waf/latest/APIReference/API_ListSubscribedRuleGroups.html"
         }
       },
+      "ListTagsForResource": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Lists the Tags for a given resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/waf/latest/APIReference/API_ListTagsForResource.html"
+        }
+      },
       "ListWebACLs": {
         "aws_action_groups": [
           "ListOnly",
@@ -77171,6 +80873,39 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/waf/latest/APIReference/API_PutPermissionPolicy.html"
+        }
+      },
+      "TagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
+        "description": "Adds a Tag to a given resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/waf/latest/APIReference/API_TagResource.html"
+        }
+      },
+      "UntagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:TagKeys"
+        ],
+        "description": "Removes a Tag from a given resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/waf/latest/APIReference/API_UntagResource.html"
         }
       },
       "UpdateByteMatchSet": {
@@ -77403,7 +81138,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a RateBasedRule, which contains a RateLimit specifying the maximum number of requests that AWS WAF allows from a specified IP address n a five-minute period.",
         "docs": {
           "api_doc": "",
@@ -77442,7 +81180,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a Rule, which contains the IPSet objects, ByteMatchSet objects, and other predicates that identify the requests that you want to lock.",
         "docs": {
           "api_doc": "",
@@ -77455,7 +81196,10 @@
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a RuleGroup. A rule group is a collection of predefined rules that you add to a WebACL.",
         "docs": {
           "api_doc": "",
@@ -77494,7 +81238,10 @@
           "Permissions"
         ],
         "calculated_action_group": "Permissions",
-        "condition_keys": [],
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
         "description": "Creates a WebACL, which contains the Rules that identify the CloudFront web requests that you want to allow, block, or count.",
         "docs": {
           "api_doc": "",
@@ -78186,6 +81933,20 @@
           "doc_page_rel": "https://docs.aws.amazon.com/waf/latest/APIReference/API_regional_ListSubscribedRuleGroups.html"
         }
       },
+      "ListTagsForResource": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Lists the Tags for a given resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/waf/latest/APIReference/API_ListTagsForResource.html"
+        }
+      },
       "ListWebACLs": {
         "aws_action_groups": [
           "ListOnly",
@@ -78240,6 +82001,39 @@
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/waf/latest/APIReference/API_regional_PutPermissionPolicy.html"
+        }
+      },
+      "TagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:RequestTag/${TagKey}",
+          "aws:TagKeys"
+        ],
+        "description": "Adds a Tag to a given resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/waf/latest/APIReference/API_TagResource.html"
+        }
+      },
+      "UntagResource": {
+        "aws_action_groups": [
+          "Tagging",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Tagging",
+        "condition_keys": [
+          "aws:TagKeys"
+        ],
+        "description": "Removes a Tag from a given resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/waf/latest/APIReference/API_UntagResource.html"
         }
       },
       "UpdateByteMatchSet": {
@@ -78451,11 +82245,24 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Creates a new workload",
+        "description": "Creates a new workload.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/wellarchitected/latest/userguide/define-workload.html"
+        }
+      },
+      "DeleteWorkload": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Deletes an existing workload.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/wellarchitected/latest/userguide/workloads-delete.html"
         }
       },
       "GetWorkload": {
@@ -78510,7 +82317,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Aborts the upload of the specified document version that was previously initiated by InitiateDocumentVersionUpload.",
+        "description": "Grants permission to abort the upload of the specified document version that was previously initiated by InitiateDocumentVersionUpload.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78523,7 +82330,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Activates the specified user. Only active users can access Amazon WorkDocs.",
+        "description": "Grants permission to activate the specified user. Only active users can access Amazon WorkDocs.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78536,7 +82343,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Creates a set of permissions for the specified folder or document.",
+        "description": "Grants permission to create a set of permissions for the specified folder or document.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78549,11 +82356,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "",
+        "description": "Grants permission to add a user to a group.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/"
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/adminguide/manage_set_admin.html"
         }
       },
       "CheckAlias": {
@@ -78563,11 +82370,37 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "",
+        "description": "Grants permission to check an alias.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/"
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/adminguide/cloud_quick_start.html"
+        }
+      },
+      "CreateComment": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to add a new comment to the specified document version.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/API_CreateComment.html"
+        }
+      },
+      "CreateCustomMetadata": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to add one or more custom properties to the specified resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/API_CreateCustomMetadata.html"
         }
       },
       "CreateFolder": {
@@ -78576,7 +82409,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Creates a folder with the specified name and parent folder.",
+        "description": "Grants permission to create a folder with the specified name and parent folder.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78589,11 +82422,24 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "",
+        "description": "Grants permission to create an instance.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/"
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/adminguide/getting_started.html"
+        }
+      },
+      "CreateLabels": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to add labels to the given resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/API_CreateLabels.html"
         }
       },
       "CreateNotificationSubscription": {
@@ -78602,7 +82448,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Configure WorkDocs to use Amazon SNS notifications.",
+        "description": "Grants permission to configure WorkDocs to use Amazon SNS notifications.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78615,7 +82461,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Creates a user in a Simple AD or Microsoft AD directory.",
+        "description": "Grants permission to create a user in a Simple AD or Microsoft AD directory.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78628,11 +82474,37 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Deactivates the specified user, which revokes the user's access to Amazon WorkDocs.",
+        "description": "Grants permission to deactivate the specified user, which revokes the user's access to Amazon WorkDocs.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/API_DeactivateUser.html"
+        }
+      },
+      "DeleteComment": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to delete the specified comment from the document version.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/API_DeleteComment.html"
+        }
+      },
+      "DeleteCustomMetadata": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to delete custom metadata from the specified resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/API_DeleteCustomMetadata.html"
         }
       },
       "DeleteDocument": {
@@ -78641,7 +82513,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Permanently deletes the specified document and its associated metadata.",
+        "description": "Grants permission to permanently delete the specified document and its associated metadata.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78654,7 +82526,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Permanently deletes the specified folder and its contents.",
+        "description": "Grants permission to permanently delete the specified folder and its contents.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78667,7 +82539,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Deletes the contents of the specified folder.",
+        "description": "Grants permission to delete the contents of the specified folder.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78680,11 +82552,24 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "",
+        "description": "Grants permission to delete an instance.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/"
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/adminguide/manage-sites.html#delete_site"
+        }
+      },
+      "DeleteLabels": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to delete one or more labels from a resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/API_DeleteLabels.html"
         }
       },
       "DeleteNotificationSubscription": {
@@ -78693,7 +82578,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Deletes the specified subscription from the specified organization.",
+        "description": "Grants permission to delete the specified subscription from the specified organization.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78706,7 +82591,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Deletes the specified user from a Simple AD or Microsoft AD directory.",
+        "description": "Grants permission to delete the specified user from a Simple AD or Microsoft AD directory.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78719,11 +82604,26 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "",
+        "description": "Grants permission to deregister a directory.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/"
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/adminguide/manage-sites.html#delete_site"
+        }
+      },
+      "DescribeActivities": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Grants permission to fetch user activities in a specified time period.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/API_DescribeActivities.html"
         }
       },
       "DescribeAvailableDirectories": {
@@ -78734,11 +82634,26 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "",
+        "description": "Grants permission to describe available directories.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/"
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/adminguide/getting_started.html"
+        }
+      },
+      "DescribeComments": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Grants permission to list all the comments for the specified document version.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/API_DescribeComments.html"
         }
       },
       "DescribeDocumentVersions": {
@@ -78749,7 +82664,7 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "Retrieves the document versions for the specified document.",
+        "description": "Grants permission to retrieve the document versions for the specified document.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78764,11 +82679,26 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "Describes the contents of the specified folder, including its documents and sub-folders.",
+        "description": "Grants permission to describe the contents of the specified folder, including its documents and sub-folders.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/API_DescribeFolderContents.html"
+        }
+      },
+      "DescribeGroups": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Grants permission to describe the user groups.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/API_DescribeGroups.html"
         }
       },
       "DescribeInstances": {
@@ -78779,11 +82709,11 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "",
+        "description": "Grants permission to describe instances.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/"
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/adminguide/getting_started.html"
         }
       },
       "DescribeNotificationSubscriptions": {
@@ -78794,7 +82724,7 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "Lists the specified notification subscriptions.",
+        "description": "Grants permission to list the specified notification subscriptions.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78809,11 +82739,26 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "Describes the permissions of a specified resource.",
+        "description": "Grants permission to view a description of a specified resource's permissions.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/API_DescribeResourcePermissions.html"
+        }
+      },
+      "DescribeRootFolders": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Grants permission to describe the root folders.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/API_DescribeRootFolders.html"
         }
       },
       "DescribeUsers": {
@@ -78824,11 +82769,39 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "Describes the specified users. You can describe all users or filter the results (for example, by status or organization).",
+        "description": "Grants permission to view a description of the specified users. You can describe all users or filter the results (for example, by status or organization).",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/API_DescribeUsers.html"
+        }
+      },
+      "DownloadDocumentVersion": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to download a specified document version.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/API_GetDocumentVersion.html"
+        }
+      },
+      "GetCurrentUser": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to retrieve the details of the current user.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/API_GetCurrentUser.html"
         }
       },
       "GetDocument": {
@@ -78838,7 +82811,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Retrieves the specified document object.",
+        "description": "Grants permission to retrieve the specified document object.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78852,7 +82825,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Retrieves the path information (the hierarchy from the root folder) for the requested document.",
+        "description": "Grants permission to retrieve the path information (the hierarchy from the root folder) for the requested document.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78866,7 +82839,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Retrieves version metadata for the specified document.",
+        "description": "Grants permission to retrieve version metadata for the specified document.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78880,7 +82853,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Retrieves the metadata of the specified folder.",
+        "description": "Grants permission to retrieve the metadata of the specified folder.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78894,11 +82867,25 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Retrieves the path information (the hierarchy from the root folder) for the specified folder.",
+        "description": "Grants permission to retrieve the path information (the hierarchy from the root folder) for the specified folder.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/API_GetFolderPath.html"
+        }
+      },
+      "GetResources": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to get a collection of resources.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/API_GetResources.html"
         }
       },
       "InitiateDocumentVersionUpload": {
@@ -78907,7 +82894,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Creates a new document object and version object.",
+        "description": "Grants permission to create a new document object and version object.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78920,11 +82907,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "",
+        "description": "Grants permission to register a directory.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/"
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/adminguide/existing-dir-setup.html"
         }
       },
       "RemoveAllResourcePermissions": {
@@ -78933,7 +82920,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Removes all the permissions from the specified resource.",
+        "description": "Grants permission to remove all the permissions from the specified resource.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78946,7 +82933,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Removes the permission for the specified principal from the specified resource.",
+        "description": "Grants permission to remove the permission for the specified principal from the specified resource.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78972,7 +82959,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Updates the specified attributes of the specified document.",
+        "description": "Grants permission to update the specified attributes of the specified document.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78985,7 +82972,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Changes the status of the document version to ACTIVE.",
+        "description": "Grants permission to change the status of the document version to ACTIVE.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -78998,7 +82985,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Updates the specified attributes of the specified folder.",
+        "description": "Grants permission to update the specified attributes of the specified folder.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -79011,11 +82998,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "",
+        "description": "Grants permission to update an instance alias.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/APIReference/"
+          "doc_page_rel": "https://docs.aws.amazon.com/workdocs/latest/adminguide/getting_started.html"
         }
       },
       "UpdateUser": {
@@ -79024,7 +83011,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Updates the specified attributes of the specified user, and grants or revokes administrative privileges to the Amazon WorkDocs site.",
+        "description": "Grants permission to update the specified attributes of the specified user, and grants or revokes administrative privileges to the Amazon WorkDocs site.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -79048,13 +83035,39 @@
   },
   "WorkLink": {
     "actions": {
+      "AssociateDomain": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to associate a domain with an Amazon WorkLink fleet",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_AssociateDomain.html"
+        }
+      },
+      "AssociateWebsiteAuthorizationProvider": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to associate a website authorization provider with an Amazon WorkLink fleet",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_AssociateWebsiteAuthorizationProvider.html"
+        }
+      },
       "AssociateWebsiteCertificateAuthority": {
         "aws_action_groups": [
           "ReadWrite"
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Associates cert with a specified fleet.",
+        "description": "Grants permission to associate a website certificate authority with an Amazon WorkLink fleet",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -79067,7 +83080,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Creates a worklink fleet.",
+        "description": "Grants permission to create an Amazon WorkLink fleet",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -79080,11 +83093,25 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Deletes the worklink fleet.",
+        "description": "Grants permission to delete an Amazon WorkLink fleet",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_DeleteFleet.html"
+        }
+      },
+      "DescribeAuditStreamConfiguration": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to describe the audit stream configuration for an Amazon WorkLink fleet",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_DescribeAuditStreamConfiguration.html"
         }
       },
       "DescribeCompanyNetworkConfiguration": {
@@ -79094,7 +83121,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Describes company network configuration for a specified fleet.",
+        "description": "Grants permission to describe the company network configuration for an Amazon WorkLink fleet",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -79108,7 +83135,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Describes a specific device associated with the fleet.",
+        "description": "Grants permission to describe details of a device associated with an Amazon WorkLink fleet",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -79122,11 +83149,25 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Describes device policy configuration for a specified fleet.",
+        "description": "Grants permission to describe the device policy configuration for an Amazon WorkLink fleet",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_DescribeDevicePolicyConfiguration.html"
+        }
+      },
+      "DescribeDomain": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Grants permission to describe details about a domain associated with an Amazon WorkLink fleet",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_DescribeDomain.html"
         }
       },
       "DescribeFleetMetadata": {
@@ -79136,7 +83177,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Describes metadata of a specified fleet.",
+        "description": "Grants permission to describe metadata of an Amazon WorkLink fleet",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -79150,7 +83191,7 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Describes identity provider configuration for a specified fleet.",
+        "description": "Grants permission to describe the identity provider configuration for an Amazon WorkLink fleet",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -79164,11 +83205,37 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Describes the cert of a specified fleet.",
+        "description": "Grants permission to describe a website certificate authority associated with an Amazon WorkLink fleet",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_DescribeWebsiteCertificateAuthority.html"
+        }
+      },
+      "DisassociateDomain": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to disassociate a domain from an Amazon WorkLink fleet",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_DisassociateDomain.html"
+        }
+      },
+      "DisassociateWebsiteAuthorizationProvider": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to disassociate a website authorization provider from an Amazon WorkLink fleet",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_DisassociateWebsiteAuthorizationProvider.html"
         }
       },
       "DisassociateWebsiteCertificateAuthority": {
@@ -79177,7 +83244,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Disassociates cert with a specified fleet.",
+        "description": "Grants permission to disassociate a website certificate authority from an Amazon WorkLink fleet",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -79192,11 +83259,26 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "Lists all the devices associated with the fleet.",
+        "description": "Grants permission to list the devices associated with an Amazon WorkLink fleet",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_ListDevices.html"
+        }
+      },
+      "ListDomains": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Grants permission to list the associated domains for an Amazon WorkLink fleet",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_ListDomains.html"
         }
       },
       "ListFleets": {
@@ -79207,11 +83289,26 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "Lists all the fleets associated with the account.",
+        "description": "Grants permission to list the Amazon WorkLink fleets associated with the account",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_ListFleets.html"
+        }
+      },
+      "ListWebsiteAuthorizationProviders": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Grants permission to list the website authorization providers for an Amazon WorkLink fleet",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_ListWebsiteAuthorizationProviders.html"
         }
       },
       "ListWebsiteCertificateAuthorities": {
@@ -79222,11 +83319,37 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "Lists all the certs associated  with the specified fleet.",
+        "description": "Grants permission to list the website certificate authorities associated with an Amazon WorkLink fleet",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_ListWebsiteCertificateAuthorities.html"
+        }
+      },
+      "RestoreDomainAccess": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to restore access to a domain associated with an Amazon WorkLink fleet",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_RestoreDomainAccess.html"
+        }
+      },
+      "RevokeDomainAccess": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to revoke access to a domain associated with an Amazon WorkLink fleet",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_RevokeDomainAccess.html"
         }
       },
       "SignOutUser": {
@@ -79235,11 +83358,24 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Signs out the specified user in a fleet.",
+        "description": "Grants permission to sign out a user from an Amazon WorkLink fleet",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_SignOutUser.html"
+        }
+      },
+      "UpdateAuditStreamConfiguration": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to update the audit stream configuration for an Amazon WorkLink fleet",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_UpdateAuditStreamConfiguration.html"
         }
       },
       "UpdateCompanyNetworkConfiguration": {
@@ -79248,7 +83384,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Updates company network configuration for a specified fleet.",
+        "description": "Grants permission to update\u00c2 the company network configuration for an Amazon WorkLink fleet",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -79261,11 +83397,24 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Updates device policy configuration for a specified fleet.",
+        "description": "Grants permission to update the device policy configuration for an Amazon WorkLink fleet",
         "docs": {
           "api_doc": "",
           "doc_page": "",
           "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_UpdateDevicePolicyConfiguration.html"
+        }
+      },
+      "UpdateDomainMetadata": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Grants permission to update the metadata for a domain associated with an Amazon WorkLink fleet",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "https://docs.aws.amazon.com/worklink/latest/api/API_UpdateDomainMetadata.html"
         }
       },
       "UpdateFleetMetadata": {
@@ -79274,7 +83423,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Updates metadata of a specified fleet.",
+        "description": "Grants permission to update the metadata of an Amazon WorkLink fleet",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -79287,7 +83436,7 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Updates identity provider configuration for a specified fleet.",
+        "description": "Grants permission to update the identity provider configuration for an Amazon WorkLink fleet",
         "docs": {
           "api_doc": "",
           "doc_page": "",
@@ -79321,7 +83470,46 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/groups_overview.html"
+        }
+      },
+      "AssociateDelegateToResource": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Adds a member (user or group) to the resource's set of delegates.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_AssociateDelegateToResource.html"
+        }
+      },
+      "AssociateMemberToGroup": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Adds a member (user or group) to the group's set.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_AssociateMemberToGroup.html"
+        }
+      },
+      "CreateAlias": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Adds an alias to the set of a given member (user or group) of WorkMail.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_CreateAlias.html"
         }
       },
       "CreateGroup": {
@@ -79330,11 +83518,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Creates a new group in the directory (but doesn't enable it for mail).",
+        "description": "Creates a group that can be used in WorkMail by calling the RegisterToWorkMail operation.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "${APIReferenceDocPage}API_CreateGroup.html"
         }
       },
       "CreateMailDomain": {
@@ -79347,7 +83535,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/add_domain.html"
         }
       },
       "CreateMailUser": {
@@ -79360,7 +83548,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/manage-users.html"
         }
       },
       "CreateOrganization": {
@@ -79373,7 +83561,7 @@
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/add_new_organization.html"
         }
       },
       "CreateResource": {
@@ -79382,11 +83570,50 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Creates a new resource",
+        "description": "Creates a new WorkMail resource.",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "${APIReferenceDocPage}API_CreateResource.html"
+        }
+      },
+      "CreateUser": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Creates a user who can be used in WorkMail by calling the RegisterToWorkMail operation.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_CreateUser.html"
+        }
+      },
+      "DeleteAlias": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Remove one or more specified aliases from a set of aliases for a given user.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_DeleteAlias.html"
+        }
+      },
+      "DeleteGroup": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Deletes a group from WorkMail.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_DeleteGroup.html"
         }
       },
       "DeleteMailDomain": {
@@ -79395,11 +83622,24 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Description for DeleteMailDomain",
+        "description": "Removes an unused mail domain from an organization",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/remove_domain.html"
+        }
+      },
+      "DeleteMailboxPermissions": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Deletes permissions granted to a member (user or group).",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_DeleteMailboxPermissions.html"
         }
       },
       "DeleteMobileDevice": {
@@ -79408,11 +83648,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Description for DeleteMobileDevice",
+        "description": "Removes a mobile device from a user",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/manage-devices.html#remove_mobile_device"
         }
       },
       "DeleteOrganization": {
@@ -79421,11 +83661,50 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Description for DeleteOrganization",
+        "description": "Removes an organization from an account, either removing the directory from directory services or leaving it available for re-use",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/remove_organization.html"
+        }
+      },
+      "DeleteResource": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Deletes the specified resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_DeleteResource.html"
+        }
+      },
+      "DeleteUser": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Deletes a user from WorkMail and all subsequent systems. The action cannot be undone.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_DeleteUser.html"
+        }
+      },
+      "DeregisterFromWorkMail": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Mark a user, group, or resource as no longer used in WorkMail.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_DeregisterFromWorkMail.html"
         }
       },
       "DescribeDirectories": {
@@ -79436,11 +83715,26 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "Description for DescribeDirectories",
+        "description": "Shows a list of directories available for use in creating an organization",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/add_new_organization.html"
+        }
+      },
+      "DescribeGroup": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Returns the data available for the group.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_DescribeGroup.html"
         }
       },
       "DescribeKmsKeys": {
@@ -79451,11 +83745,11 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "Description for DescribeKmsKeys",
+        "description": "Shows a list of KMS Keys available for use in creating an organization",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/add_new_organization.html"
         }
       },
       "DescribeMailDomains": {
@@ -79466,11 +83760,11 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "Description for DescribeMailDomains",
+        "description": "Shows the details of all mail domains associated with the organization",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/domains_overview.html"
         }
       },
       "DescribeMailGroups": {
@@ -79481,11 +83775,11 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "Description for DescribeMailGroups",
+        "description": "Shows the details of all groups associated with the organization",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/groups_overview.html"
         }
       },
       "DescribeMailUsers": {
@@ -79496,11 +83790,26 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "Description for DescribeMailUsers",
+        "description": "Shows the details of all users associated with the orgaization",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/users_overview.html"
+        }
+      },
+      "DescribeOrganization": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Provides more information regarding a given organization based on its identifier.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_DescribeOrganization.html"
         }
       },
       "DescribeOrganizations": {
@@ -79511,11 +83820,41 @@
         ],
         "calculated_action_group": "List",
         "condition_keys": [],
-        "description": "Description for DescribeOrganizations",
+        "description": "Shows a summary of all organizations associated with the account",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/organizations_overview.html"
+        }
+      },
+      "DescribeResource": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Returns the data available for the resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_DescribeResource.html"
+        }
+      },
+      "DescribeUser": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Provides information regarding the user.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_DescribeUser.html"
         }
       },
       "DisableMailGroups": {
@@ -79524,11 +83863,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Description for DisableMailGroups",
+        "description": "Disable a mail group when it is not being used and, to allow it to be deleted",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/remove_group.html"
         }
       },
       "DisableMailUsers": {
@@ -79537,11 +83876,37 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Description for DisableMailUsers",
+        "description": "Disable a user mailbox when it is no longer being used, and to allow it to be deleted",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/manage-mailboxes.html#delete_user_mailbox"
+        }
+      },
+      "DisassociateDelegateFromResource": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Removes a member from the resource's set of delegates.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_DisassociateDelegateFromResource.html"
+        }
+      },
+      "DisassociateMemberFromGroup": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Removes a member from a group.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_DisassociateMemberFromGroup.html"
         }
       },
       "EnableMailDomain": {
@@ -79550,11 +83915,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Description for EnableMailDomain",
+        "description": "Enable a mail domain in the organization",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/add_domain.html"
         }
       },
       "EnableMailGroups": {
@@ -79563,11 +83928,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Description for EnableMailGroups",
+        "description": "Enable a mail group after it has been created to allow it to receive mail",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/enable_existing_group.html"
         }
       },
       "EnableMailUsers": {
@@ -79576,11 +83941,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Description for EnableMailUsers",
+        "description": "Enable a user's mailbox after it has been created to allow it to receive mail",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/manage-users.html#enable_existing_user"
         }
       },
       "GetMailDomainDetails": {
@@ -79590,11 +83955,11 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Description for GetMailDomainDetails",
+        "description": "Get the details of the mail domain",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/domains_overview.html"
         }
       },
       "GetMailGroupDetails": {
@@ -79604,11 +83969,11 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Description for GetMailGroupDetails",
+        "description": "Get the details of the mail group",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/groups_overview.html"
         }
       },
       "GetMailUserDetails": {
@@ -79618,11 +83983,25 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Description for GetMailUserDetails",
+        "description": "Get the details of the user's mailbox and account",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/users_overview.html"
+        }
+      },
+      "GetMailboxDetails": {
+        "aws_action_groups": [
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Read",
+        "condition_keys": [],
+        "description": "Returns the details of the user's mailbox.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_GetMailboxDetails.html"
         }
       },
       "GetMobileDeviceDetails": {
@@ -79632,11 +84011,11 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Description for GetMobileDeviceDetails",
+        "description": "Get the details of the mobile device",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/manage-devices.html"
         }
       },
       "GetMobileDevicesForUser": {
@@ -79646,11 +84025,11 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Description for GetMobileDevicesForUser",
+        "description": "Get a list of the mobile devices associated with the user",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/manage-devices.html"
         }
       },
       "GetMobilePolicyDetails": {
@@ -79660,11 +84039,71 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Description for GetMobilePolicyDetails",
+        "description": "Get the details of the mobile device policy associated with the organization",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/edit_organization_mobile_policy.html"
+        }
+      },
+      "ListAliases": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Creates a paginated call to list the aliases associated with a given entity.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_ListAliases.html"
+        }
+      },
+      "ListGroupMembers": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Returns an overview of the members of a group. Users and groups can be members of a group.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_ListGroupMembers.html"
+        }
+      },
+      "ListGroups": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Returns summaries of the organization's groups.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_ListGroups.html"
+        }
+      },
+      "ListMailboxPermissions": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Lists the mailbox permissions associated with a user, group, or resource mailbox.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_ListMailboxPermissions.html"
         }
       },
       "ListMembersInMailGroup": {
@@ -79674,11 +84113,97 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Description for ListMembersInMailGroup",
+        "description": "Get a list of all the members in a mail group",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/groups_overview.html"
+        }
+      },
+      "ListOrganizations": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Returns summaries of the customer's non-deleted organizations.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_ListOrganizations.html"
+        }
+      },
+      "ListResourceDelegates": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Lists the delegates associated with a resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_ListResourceDelegates.html"
+        }
+      },
+      "ListResources": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Returns summaries of the organization's resources.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_ListResources.html"
+        }
+      },
+      "ListUsers": {
+        "aws_action_groups": [
+          "ListOnly",
+          "ReadOnly",
+          "ReadWrite"
+        ],
+        "calculated_action_group": "List",
+        "condition_keys": [],
+        "description": "Returns summaries of the organization's users.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_ListUsers.html"
+        }
+      },
+      "PutMailboxPermissions": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Sets permissions for a user, group, or resource. This replaces any pre-existing permissions.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_PutMailboxPermissions.html"
+        }
+      },
+      "RegisterToWorkMail": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Registers an existing and disabled user, group, or resource for use by associating a mailbox and calendaring capabilities.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_RegisterToWorkMail.html"
         }
       },
       "RemoveMembersFromGroup": {
@@ -79687,11 +84212,24 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Description for RemoveMembersFromGroup",
+        "description": "Remove members from a mail group",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/groups_overview.html"
+        }
+      },
+      "ResetPassword": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Allows the administrator to reset the password for a user.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_ResetPassword.html"
         }
       },
       "ResetUserPassword": {
@@ -79700,11 +84238,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Description for ResetUserPassword",
+        "description": "Reset the password for a user's account",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/manage-users.html#reset_user_password"
         }
       },
       "SearchMembers": {
@@ -79714,11 +84252,11 @@
         ],
         "calculated_action_group": "Read",
         "condition_keys": [],
-        "description": "Description for SearchMembers",
+        "description": "Prefix search to find a specific user in a mail group",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/groups_overview.html"
         }
       },
       "SetAdmin": {
@@ -79727,11 +84265,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Description for SetAdmin",
+        "description": "Mark a user as being an administrator",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/users_overview.html"
         }
       },
       "SetDefaultMailDomain": {
@@ -79740,11 +84278,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Description for SetDefaultMailDomain",
+        "description": "Set the default mail domain for the organization",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/default_domain.html"
         }
       },
       "SetMailGroupDetails": {
@@ -79753,11 +84291,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Description for SetMailGroupDetails",
+        "description": "Set the details of the mail group which has just been created",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/add_new_group.html"
         }
       },
       "SetMailUserDetails": {
@@ -79766,11 +84304,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Description for SetMailUserDetails",
+        "description": "Set the details for the user account which has just been created",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/manage-users.html"
         }
       },
       "SetMobilePolicyDetails": {
@@ -79779,11 +84317,50 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Description for SetMobilePolicyDetails",
+        "description": "Set the details of a mobile policy associated with the organization",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/edit_organization_mobile_policy.html"
+        }
+      },
+      "UpdateMailboxQuota": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Updates the maximum size (in MB) of the user's mailbox.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_UpdateMailboxQuota.html"
+        }
+      },
+      "UpdatePrimaryEmailAddress": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Updates the primary email for a user, group, or resource.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_UpdatePrimaryEmailAddress.html"
+        }
+      },
+      "UpdateResource": {
+        "aws_action_groups": [
+          "ReadWrite"
+        ],
+        "calculated_action_group": "Write",
+        "condition_keys": [],
+        "description": "Updates data for the resource. To retrieve the latest information, it must be preceded by a DescribeResource call.",
+        "docs": {
+          "api_doc": "",
+          "doc_page": "",
+          "doc_page_rel": "${APIReferenceDocPage}API_UpdateResource.html"
         }
       },
       "WipeMobileDevice": {
@@ -79792,11 +84369,11 @@
         ],
         "calculated_action_group": "Write",
         "condition_keys": [],
-        "description": "Description for WipeMobileDevice",
+        "description": "Remotely wipe the mobile device associated with a user's account",
         "docs": {
           "api_doc": "",
           "doc_page": "",
-          "doc_page_rel": ""
+          "doc_page_rel": "https://docs.aws.amazon.com/workmail/latest/adminguide/manage-devices.html#remote_wipe_device"
         }
       }
     },


### PR DESCRIPTION
This pull request updates data.json using the latest IAM Actions, Resources, and Condition Keys AWS documentation (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_actions-resources-contextkeys.html)

The following items were added if a match was not present:
- actions
- condition_keys for actions

The following items were updated if a change was detected:
- action description
- calculated_action_group and aws_action_groups (unless documented version is 'tagging' - this is almost always a documentation problem)
- doc_page_rel

The following things were not changed:
- new services (better left to a separate pull request)
- actions missing from documentation
- condition_keys missing from documentation
- api_doc and doc_page fields

This PR should cover about 95% of all of the missing information in the data file. If this is able to be merged, I'll look at adding the missing non-beta services next. Apologies in advance for the massive diff! 😇

Fixes #27 and #29