### PR TITLE
Addressing the missing actions for same service names e.g. ELB

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Version](http://img.shields.io/pypi/v/policyuniverse.svg?style=flat)](https://pypi.python.org/pypi/policyuniverse/)
 
-[![Build Status](https://travis-ci.org/Netflix-Skunkworks/policyuniverse.svg?branch=master)](https://travis-ci.org/Netflix-Skunkworks/policyuniverse)
+[![Build Status](https://github.com/Netflix-Skunkworks/policyuniverse/workflows/Python%20package/badge.svg)](https://github.com/Netflix-Skunkworks/policyuniverse/actions)
 
 [![Coverage Status](https://coveralls.io/repos/github/Netflix-Skunkworks/policyuniverse/badge.svg?branch=master&1)](https://coveralls.io/github/Netflix-Skunkworks/policyuniverse?branch=master)
 

--- a/updater/awsconsole.js
+++ b/updater/awsconsole.js
@@ -94,7 +94,7 @@ var advisor = function() {
                     function(service_url) {
                         var service_data = results['services']['_embedded'][service_url];
                         var actions_url = service_data['_links']['actions']['href'];
-                        var service_name = service_data['serviceDisplayName']; // Some services may have same service name so using display name
+                        var service_name = service_data['serviceName'];
                         progress[actions_url] = "NOT_STARTED";
                         results['actions'] = {};
                         collectServiceActions(actions_url, service_name);

--- a/updater/updater.py
+++ b/updater/updater.py
@@ -93,7 +93,7 @@ def parse_service_data(data):
     services = defaultdict()
     for service_url, service_details in data["services"]["_embedded"].items():
         service = Service(service_url, service_details)
-        services[service.display_name] = service
+        services[service.service_name] = service
     return services
 
 

--- a/updater/updater.py
+++ b/updater/updater.py
@@ -93,7 +93,7 @@ def parse_service_data(data):
     services = defaultdict()
     for service_url, service_details in data["services"]["_embedded"].items():
         service = Service(service_url, service_details)
-        services[service.service_name] = service
+        services[service.display_name] = service
     return services
 
 


### PR DESCRIPTION
Hello - we ran into issue of ELB v1 actions are not recognized by policyuniverse. We did analyses it turns out be ELB v1 and v2 uses the same service name which is getting overwritten in the action generation process - `data.json`.

Credit goes to @ksenthilmurugan, he identified and able to address this issue.

Kindly review and merge this PR. So that we take the latest pip lib version after publish. Thanks.

Feel free to improve it as you see fit.