### PR TITLE
Feature/federated principal

### DIFF
--- a/policyuniverse/statement.py
+++ b/policyuniverse/statement.py
@@ -128,6 +128,9 @@ class Statement(object):
             if "Service" in principal:
                 self._add_or_extend(principal["Service"], principals)
 
+            if "Federated" in principal:
+                self._add_or_extend(principal["Federated"], principals)
+
         else:
             self._add_or_extend(principal, principals)
 

--- a/policyuniverse/statement.py
+++ b/policyuniverse/statement.py
@@ -180,6 +180,9 @@ class Statement(object):
             "aws:sourceip": "cidr",
             "aws:sourcevpc": "vpc",
             "aws:sourcevpce": "vpce",
+            # a key for SAML Federation trust policy.
+            # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_saml.html
+            # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html
             "saml:aud": "saml-endpoint"
         }
 

--- a/policyuniverse/statement.py
+++ b/policyuniverse/statement.py
@@ -180,6 +180,7 @@ class Statement(object):
             "aws:sourceip": "cidr",
             "aws:sourcevpc": "vpc",
             "aws:sourcevpce": "vpce",
+            "saml:aud": "saml-endpoint"
         }
 
         relevant_condition_operators = [


### PR DESCRIPTION
-  Added a `Federated` principle for cases of SAML Federation 
- Added a condition key that is specific for SAML trust policies 
When creating a Role for `SAML 2,0 Federation`, and selecting  `Allow programmatic and AWS Management Console access`, AWS automatically creates the attribute `SAML:aud` with value `https://signin.aws.amazon.com/saml`. 
https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_saml.html

