### PR TITLE
Adding new miscategorized AWS action to unit tests.

### DIFF
--- a/policyuniverse/action_categories.py
+++ b/policyuniverse/action_categories.py
@@ -12,19 +12,19 @@ def translate_aws_action_groups(groups):
         - ListOnly
         - ReadOnly
         - Tagging
-    
+
     The meaning of these groups was not immediately obvious to me.
-    
+
     Permissions: ability to modify (create/update/remove) permissions.
     ReadWrite: Indicates a data-plane operation.
     ReadOnly: Always used with ReadWrite. Indicates a read-only data-plane operation.
     ListOnly: Always used with [ReadWrite, ReadOnly]. Indicates an action which
         lists resources, which is a subcategory of read-only data-plane operations.
     Tagging: Always used with ReadWrite. Indicates a permission that can mutate tags.
-    
+
     So an action with ReadWrite, but without ReadOnly, is a mutating data-plane operation.
     An action with Permission never has any other groups.
-    
+
     This method will take the AWS categories and translate them to one of the following:
 
     - List
@@ -61,9 +61,9 @@ def build_action_categories_from_service_data(service_data):
 def categories_for_actions(actions):
     """
     Given an iterable of actions, return a mapping of action groups.
-    
+
     actions: {'ec2:authorizesecuritygroupingress', 'iam:putrolepolicy', 'iam:listroles'}
-    
+
     Returns:
         {
             'ec2': {'Write'},
@@ -80,10 +80,10 @@ def categories_for_actions(actions):
 def actions_for_category(category):
     """
     Returns set of actions containing each group passed in.
-    
+
     Param:
         category must be in {'Permissions', 'List', 'Read', 'Tagging', 'Write'}
-    
+
     Returns:
         set of matching actions
     """

--- a/policyuniverse/statement.py
+++ b/policyuniverse/statement.py
@@ -76,9 +76,9 @@ class Statement(object):
 
     def whos_allowed(self):
         """Returns set containing any entries from principal and condition section.
-        
+
         Example:
-        
+
         statement = Statement(dict(
             Effect='Allow',
             Principal='arn:aws:iam::*:role/Hello',
@@ -144,16 +144,16 @@ class Statement(object):
 
     def _condition_entries(self):
         """Extracts any ARNs, Account Numbers, UserIDs, Usernames, CIDRs, VPCs, and VPC Endpoints from a condition block.
-        
+
         Ignores any negated condition operators like StringNotLike.
         Ignores weak condition keys like referer, date, etc.
-        
+
         Reason: A condition is meant to limit the principal in a statement.  Often, resource policies use a wildcard principal
         and rely exclusively on the Condition block to limit access.
-        
+
         We would want to alert if the Condition had no limitations (like a non-existent Condition block), or very weak limitations.  Any negation
         would be weak, and largely equivelant to having no condition block whatsoever.
-        
+
         The alerting code that relies on this data must ensure the condition has at least one of the following:
         - A limiting ARN
         - Account Identifier
@@ -183,7 +183,7 @@ class Statement(object):
             # a key for SAML Federation trust policy.
             # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_saml.html
             # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html
-            "saml:aud": "saml-endpoint"
+            "saml:aud": "saml-endpoint",
         }
 
         relevant_condition_operators = [

--- a/policyuniverse/tests/test_action_categories.py
+++ b/policyuniverse/tests/test_action_categories.py
@@ -89,6 +89,7 @@ class ActionGroupTestCase(unittest.TestCase):
                 "personalize:getpersonalizedranking",
                 "redshift:getclustercredentials",
                 "states:getactivitytask",
+                "quicksight:describecustompermissions",
             }:  # miscategorized AWS actions
                 continue
             self.assertFalse(":get" in action)


### PR DESCRIPTION
Adding `quicksight:describecustompermissions` to the list of actions that seem to be categorized as WRITE actions even though they begin with `Describe`.

Should fix all unit tests.