### PR TITLE
Update the list of miscategorized actions in the unit tests - fixes Netflix-Skunkworks/policyuniverse#86

### DIFF
--- a/policyuniverse/tests/test_action_categories.py
+++ b/policyuniverse/tests/test_action_categories.py
@@ -53,7 +53,7 @@ class ActionGroupTestCase(unittest.TestCase):
                 "imagebuilder:getimagepolicy",
                 "imagebuilder:getimagerecipepolicy",
                 "signer:listprofilepermissions",
-                "monitron:listprojectadminusers"
+                "monitron:listprojectadminusers",
             }:  # miscategorized AWS actions
                 continue
 
@@ -93,7 +93,7 @@ class ActionGroupTestCase(unittest.TestCase):
                 "states:getactivitytask",
                 "quicksight:describecustompermissions",
                 "cloudshell:getfiledownloadurls",
-                "cloudshell:getfileuploadurls"
+                "cloudshell:getfileuploadurls",
             }:  # miscategorized AWS actions
                 continue
             self.assertFalse(":get" in action)

--- a/policyuniverse/tests/test_action_categories.py
+++ b/policyuniverse/tests/test_action_categories.py
@@ -52,6 +52,8 @@ class ActionGroupTestCase(unittest.TestCase):
                 "imagebuilder:getcomponentpolicy",
                 "imagebuilder:getimagepolicy",
                 "imagebuilder:getimagerecipepolicy",
+                "signer:listprofilepermissions",
+                "monitron:listprojectadminusers"
             }:  # miscategorized AWS actions
                 continue
 
@@ -90,6 +92,8 @@ class ActionGroupTestCase(unittest.TestCase):
                 "redshift:getclustercredentials",
                 "states:getactivitytask",
                 "quicksight:describecustompermissions",
+                "cloudshell:getfiledownloadurls",
+                "cloudshell:getfileuploadurls"
             }:  # miscategorized AWS actions
                 continue
             self.assertFalse(":get" in action)


### PR DESCRIPTION
$python -m pytest
============================= test session starts ==============================
platform linux -- Python 3.9.1, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
rootdir: /home/bardon/workspace/fork_space/policyuniverse
collected 32 items                                                             

policyuniverse/tests/test_action_categories.py ..                        [  6%]
policyuniverse/tests/test_arn.py ..                                      [ 12%]
policyuniverse/tests/test_expander_minimizer.py ............             [ 50%]
policyuniverse/tests/test_policy.py .......                              [ 71%]
policyuniverse/tests/test_statement.py ......                            [ 90%]
updater/test_service.py .                                                [ 93%]
updater/test_service_action.py ..                                        [100%]

============================== 32 passed in 2.37s ==============================