### PR TITLE
Add license metadata to python package declaration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,8 @@ setup(
     package_data={"policyuniverse": ["data.json"]},
     include_package_data=True,
     zip_safe=False,
+    classifiers=[
+        'License :: OSI Approved :: Apache Software License'
+    ],
     extras_require={"tests": tests_require, "dev": dev_require},
 )


### PR DESCRIPTION
I am trying to import this package into an internal repository using an internal procurement process and it is failing to find the license, I would like to add this additional license metadata to the python package to see if that will help.

Also, I did not find release instructions, could you help me process this change for release to the PyPI repository?

Thanks!