### PR TITLE
Optimize action expansion logic

### DIFF
--- a/policyuniverse/expander_minimizer.py
+++ b/policyuniverse/expander_minimizer.py
@@ -78,7 +78,7 @@ def _expand_wildcard_action(actions):
     if isinstance(actions, str):
         # Bail early if we have a string with no wildcard
         if "*" not in actions:
-            return [actions]
+            return [actions.lower()]
         actions = [actions]
 
     # Map _expand function to action list, resulting in a list of lists of expanded actions.

--- a/policyuniverse/expander_minimizer.py
+++ b/policyuniverse/expander_minimizer.py
@@ -57,31 +57,38 @@ def _get_prefixes_for_action(action):
     return retval
 
 
-def _expand_wildcard_action(action):
+def _expand(action):
     """
     :param action: 'autoscaling:*'
     :return: A list of all autoscaling permissions matching the wildcard
     """
-    if isinstance(action, list):
-        expanded_actions = []
-        for item in action:
-            expanded_actions.extend(_expand_wildcard_action(item))
-        return expanded_actions
+    expanded = fnmatch.filter(all_permissions, action.lower())
+    # if we get a wildcard for a tech we've never heard of, just return the wildcard
+    if not expanded:
+        return [action]
+    return expanded
 
-    else:
-        if "*" in action:
-            expanded = [
-                expanded_action.lower()
-                for expanded_action in all_permissions
-                if fnmatch.fnmatchcase(expanded_action.lower(), action.lower())
-            ]
 
-            # if we get a wildcard for a tech we've never heard of, just return the wildcard
-            if not expanded:
-                return [action.lower()]
+def _expand_wildcard_action(actions):
+    """Expand wildcards in a list of actions (or a single action string), returning a list of all matching actions.
 
-            return expanded
-        return [action.lower()]
+    :param actions: ['autoscaling:*']
+    :return: A list of all permissions matching the action globs
+    """
+    if isinstance(actions, str):
+        # Bail early if we have a string with no wildcard
+        if "*" not in actions:
+            return [actions]
+        actions = [actions]
+
+    # Map _expand function to action list, resulting in a list of lists of expanded actions.
+    temp = map(_expand, actions)
+
+    # This flattens the list of lists. It's hard to read, but it's a hot path and the optimization
+    # speeds it up by 90% or more.
+    expanded = [item.lower() for sublist in temp for item in sublist]
+
+    return expanded
 
 
 def _get_desired_actions_from_statement(statement):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ dev_require = ["pre-commit", "black"]
 
 setup(
     name="policyuniverse",
-    version="1.3.2.20210114",
+    version="1.3.3.20210114",
     description="Parse and Process AWS IAM Policies, Statements, ARNs, and wildcards.",
     long_description=open(os.path.join(ROOT, "README.md")).read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR optimizes a hot path in the action wildcard expansion flow. The `_expand_wildcard_action()` function now maps a new `_expand()` function over the list of actions. For the `_expand()` function, I opted to use `fnmatch.filter()` instead of `fnmatch.fnmatchcase()` for a pretty significant performance improvement.

The `_expand_wildcard_action()` has a _really_ ugly list comprehension to flatten a list of lists. It's basically impossible to read, but there's another significant performance improvement with this change. StackOverflow reference for the ugly part: https://stackoverflow.com/a/952952

With some quick profiling, the changes in this PR decreased the time Repokid spent in this codepath from 30 seconds to 10 seconds for a collection of ~100 roles.