### PR TITLE
Allow all array Sequence sub-classes to be used in policy documents

### DIFF
--- a/policyuniverse/common.py
+++ b/policyuniverse/common.py
@@ -1,0 +1,56 @@
+#     Copyright 2014 Netflix, Inc.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: policyuniverse.tests.test_common
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor::  George Psarakis <giwrgos.psarakis@gmail.com>
+
+"""
+
+try:
+    from collections.abc import Sequence
+except ImportError:
+    # Python 2.7 compatibility
+    from collections import Sequence
+
+try:
+    # Python 2.7 compatibility
+    _STRING_TYPES = (bytes, str, unicode)
+except NameError:
+    _STRING_TYPES = (bytes, str)
+
+
+def is_array(obj):
+    """
+    Check if the object is iterable, excluding strings:
+    - tuple
+    - list
+    - collections.abc.Sequence sub-class
+    """
+    if isinstance(obj, _STRING_TYPES):
+        return False
+    return isinstance(obj, Sequence)
+
+
+def ensure_array(obj):
+    """
+    Ensures that the given object is an array,
+    by creating a list and adding it as a single element.
+    """
+    if is_array(obj):
+        return obj
+    else:
+        return [obj]

--- a/policyuniverse/expander_minimizer.py
+++ b/policyuniverse/expander_minimizer.py
@@ -21,6 +21,7 @@
 """
 from __future__ import print_function
 from policyuniverse import all_permissions
+from policyuniverse.common import ensure_array
 import json
 import fnmatch
 import sys
@@ -171,17 +172,15 @@ def minimize_statement_actions(statement, minchars=None):
 def get_actions_from_statement(statement):
     allowed_actions = set()
 
-    if not type(statement.get("Action", [])) == list:
-        statement["Action"] = [statement["Action"]]
+    statement["Action"] = ensure_array(statement.get("Action", []))
 
-    for action in statement.get("Action", []):
+    for action in statement["Action"]:
         allowed_actions = allowed_actions.union(set(_expand_wildcard_action(action)))
 
-    if not type(statement.get("NotAction", [])) == list:
-        statement["NotAction"] = [statement["NotAction"]]
+    statement["NotAction"] = ensure_array(statement.get("NotAction", []))
 
     inverted_actions = set()
-    for action in statement.get("NotAction", []):
+    for action in statement["NotAction"]:
         inverted_actions = inverted_actions.union(set(_expand_wildcard_action(action)))
 
     if inverted_actions:
@@ -201,8 +200,7 @@ def expand_policy(policy=None, expand_deny=False):
     # Perform a deepcopy to avoid mutating the input
     result = copy.deepcopy(policy)
 
-    if type(result["Statement"]) is dict:
-        result["Statement"] = [result["Statement"]]
+    result["Statement"] = ensure_array(result["Statement"])
     for statement in result["Statement"]:
         if statement["Effect"].lower() == "deny" and not expand_deny:
             continue

--- a/policyuniverse/expander_minimizer.py
+++ b/policyuniverse/expander_minimizer.py
@@ -171,16 +171,15 @@ def minimize_statement_actions(statement, minchars=None):
 
 def get_actions_from_statement(statement):
     allowed_actions = set()
+    actions = ensure_array(statement.get("Action", []))
 
-    statement["Action"] = ensure_array(statement.get("Action", []))
-
-    for action in statement["Action"]:
+    for action in actions:
         allowed_actions = allowed_actions.union(set(_expand_wildcard_action(action)))
 
-    statement["NotAction"] = ensure_array(statement.get("NotAction", []))
-
     inverted_actions = set()
-    for action in statement["NotAction"]:
+    not_actions = ensure_array(statement.get("NotAction", []))
+
+    for action in not_actions:
         inverted_actions = inverted_actions.union(set(_expand_wildcard_action(action)))
 
     if inverted_actions:

--- a/policyuniverse/policy.py
+++ b/policyuniverse/policy.py
@@ -20,6 +20,7 @@
 
 """
 from policyuniverse.statement import Statement
+from policyuniverse.common import ensure_array
 from collections import defaultdict
 
 
@@ -28,9 +29,7 @@ class Policy(object):
         self.policy = policy
         self.statements = []
 
-        statement_structure = self.policy.get("Statement", [])
-        if not isinstance(statement_structure, list):
-            statement_structure = [statement_structure]
+        statement_structure = ensure_array(self.policy.get("Statement", []))
 
         for statement in statement_structure:
             self.statements.append(Statement(statement))

--- a/policyuniverse/statement.py
+++ b/policyuniverse/statement.py
@@ -20,12 +20,10 @@
 
 """
 from policyuniverse.arn import ARN
-from policyuniverse.expander_minimizer import (
-    _expand_wildcard_action,
-    get_actions_from_statement,
-)
+from policyuniverse.expander_minimizer import get_actions_from_statement
 from policyuniverse import logger
 from policyuniverse.action_categories import categories_for_actions
+from policyuniverse.common import ensure_array, is_array
 
 import re
 from collections import namedtuple
@@ -54,8 +52,7 @@ class Statement(object):
         actions = self.statement.get("Action")
         if not actions:
             return set()
-        if not isinstance(actions, list):
-            actions = [actions]
+        actions = ensure_array(actions)
         return set(actions)
 
     def action_summary(self):
@@ -69,9 +66,7 @@ class Statement(object):
         if "NotResource" in self.statement:
             return set(["*"])
 
-        resources = self.statement.get("Resource")
-        if not isinstance(resources, list):
-            resources = [resources]
+        resources = ensure_array(self.statement.get("Resource"))
         return set(resources)
 
     def whos_allowed(self):
@@ -137,7 +132,7 @@ class Statement(object):
         return principals
 
     def _add_or_extend(self, value, structure):
-        if isinstance(value, list):
+        if is_array(value):
             structure.update(set(value))
         else:
             structure.add(value)
@@ -209,13 +204,13 @@ class Statement(object):
 
                     # ForAllValues and ForAnyValue must be paired with a list.
                     # Otherwise, skip over entries.
-                    if not isinstance(
-                        value, list
-                    ) and condition_operator.lower().startswith("for"):
+                    if not is_array(value) and condition_operator.lower().startswith(
+                        "for"
+                    ):
                         continue
 
                     if key.lower() in key_mapping:
-                        if isinstance(value, list):
+                        if is_array(value):
                             for v in value:
                                 conditions.append(
                                     ConditionTuple(

--- a/policyuniverse/tests/test_common.py
+++ b/policyuniverse/tests/test_common.py
@@ -1,0 +1,61 @@
+#     Copyright 2014 Netflix, Inc.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: policyuniverse.tests.test_common
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor::  George Psarakis <giwrgos.psarakis@gmail.com>
+
+"""
+from policyuniverse.common import is_array, ensure_array
+import unittest
+from collections.abc import Sequence
+
+
+class CustomSequence(Sequence):
+    def __init__(self, *elements):
+        self._elements = elements
+
+    def __getitem__(self, item):
+        return self._elements[item]
+
+    def __len__(self):
+        return self._elements.__len__()
+
+    def __iter__(self):
+        return iter(self._elements)
+
+
+class CommonTestCase(unittest.TestCase):
+    def test_is_array(self):
+        cases = (
+            ([1, 2], True),
+            ((1, 2), True),
+            (CustomSequence(1, 2), True),
+            ("abc", False),
+            (b"abc", False),
+            (1, False),
+            ({"a": 1}, False),
+        )
+        for case_input, expected in cases:
+            self.assertIs(is_array(case_input), expected)
+
+    def test_ensure_array_sequence_input(self):
+        for obj in ([1, 2], (3, 4), CustomSequence(5, 6)):
+            self.assertIs(ensure_array(obj), obj)
+
+    def test_ensure_array_non_sequence_input(self):
+        for obj in ("abc", b"abc", 1, {"a": 1}):
+            self.assertListEqual(ensure_array(obj), [obj])

--- a/policyuniverse/tests/test_expander_minimizer.py
+++ b/policyuniverse/tests/test_expander_minimizer.py
@@ -226,7 +226,26 @@ class TestMethods(unittest.TestCase):
         expected_result = {"ec2:thispermissiondoesntexist"}
         result = get_actions_from_statement(statement)
         self.assertEqual(result, expected_result)
-        get_actions_from_statement(dict(NotAction="abc"))
+        result = get_actions_from_statement(dict(NotAction="abc"))
+        self.assertSetEqual(result, set(all_permissions))
+
+        statement = {
+            "Action": (
+                "ec2:updatesecuritygroupruledescriptionsegress",
+                "ec2:cancelcapacityreservation",
+            ),
+            "NotAction": tuple(),
+            "Resource": "*",
+            "Effect": "Allow",
+        }
+        result = get_actions_from_statement(statement)
+        self.assertSetEqual(
+            result,
+            {
+                "ec2:updatesecuritygroupruledescriptionsegress",
+                "ec2:cancelcapacityreservation",
+            },
+        )
 
     def test_minimize_statement_actions(self):
         statement = dict(Effect="Deny")

--- a/policyuniverse/tests/test_policy.py
+++ b/policyuniverse/tests/test_policy.py
@@ -238,3 +238,23 @@ class PolicyTestCase(unittest.TestCase):
 
         policy = Policy(json.loads(SQS_NOTIFICATION_POLICY))
         self.assertTrue(policy.is_internet_accessible())
+
+    def test_non_list_sequence_statement(self):
+        policy_document = dict(
+            Version="2012-10-08",
+            Statement=(
+                dict(
+                    Effect="Allow",
+                    Principal="*",
+                    Action=["rds:*"],
+                    Resource="*",
+                    Condition={"IpAddress": {"AWS:SourceIP": ["0.0.0.0/0"]}},
+                ),
+            ),
+        )
+        policy = Policy(policy_document)
+        self.assertTrue(policy.is_internet_accessible())
+        self.assertListEqual(
+            list(s.statement for s in policy.statements),
+            [policy_document["Statement"][0]],
+        )


### PR DESCRIPTION
- [x] Add a `common` module with type-checking utilities.
- [x] Define method that ensures object is array-like, wrapping in a `list` if it is not a container.
- [x] Define method that provides a boolean check whether the object is array-like.
- [x] Add test cases.  

Closes #94.