### PR TITLE
Expand type checking to any Mapping sub-class for Principals

### DIFF
--- a/policyuniverse/statement.py
+++ b/policyuniverse/statement.py
@@ -28,6 +28,11 @@ from policyuniverse.common import ensure_array, is_array
 import re
 from collections import namedtuple
 
+try:
+    from collections.abc import Mapping
+except ImportError:
+    # Python 2.7 compatibility
+    from collections import Mapping
 
 PrincipalTuple = namedtuple("Principal", "category value")
 ConditionTuple = namedtuple("Condition", "category value")
@@ -115,7 +120,7 @@ class Statement(object):
             # It is possible not to define a principal, AWS ignores these statements.
             return principals
 
-        if isinstance(principal, dict):
+        if isinstance(principal, Mapping):
 
             if "AWS" in principal:
                 self._add_or_extend(principal["AWS"], principals)

--- a/policyuniverse/tests/helpers.py
+++ b/policyuniverse/tests/helpers.py
@@ -1,0 +1,27 @@
+from policyuniverse.statement import Mapping
+from policyuniverse.common import Sequence
+
+
+class CustomSequence(Sequence):
+    def __init__(self, data):
+        self._sequence = data
+
+    def __getitem__(self, item):
+        return self._sequence[item]
+
+    def __len__(self):
+        return len(self._sequence)
+
+
+class CustomMapping(Mapping):
+    def __init__(self, data):
+        self._mapping = data
+
+    def __getitem__(self, item):
+        return self._mapping[item]
+
+    def __len__(self):
+        return len(self._mapping)
+
+    def __iter__(self):
+        return iter(self._mapping)

--- a/policyuniverse/tests/test_policy.py
+++ b/policyuniverse/tests/test_policy.py
@@ -24,6 +24,8 @@ from policyuniverse import logger
 import unittest
 import json
 
+from .helpers import CustomMapping, CustomSequence
+
 
 policy01 = dict(
     Version="2012-10-08",
@@ -120,6 +122,26 @@ policy06 = dict(
             Condition={"StringEquals": {"AWS:PrincipalOrgID": "o-xxxxxxxxxx"}},
         )
     ],
+)
+
+# Custom types
+policy07 = CustomMapping(
+    dict(
+        Statement=CustomSequence(
+            [
+                CustomMapping(
+                    dict(
+                        Action="s3:GetBucketAcl",
+                        Effect="Allow",
+                        Principal=CustomMapping({"AWS": "*"}),
+                        Resource="arn:aws:s3:::example-bucket",
+                        Sid="Public Access",
+                    )
+                )
+            ]
+        ),
+        Version="2012-10-17",
+    )
 )
 
 
@@ -258,3 +280,8 @@ class PolicyTestCase(unittest.TestCase):
             list(s.statement for s in policy.statements),
             [policy_document["Statement"][0]],
         )
+
+    def test_mapping_and_sequence_policy_document(self):
+        policy = Policy(policy07)
+        self.assertSetEqual(policy.principals, set("*"))
+        self.assertIs(policy.is_internet_accessible(), True)

--- a/policyuniverse/tests/test_statement.py
+++ b/policyuniverse/tests/test_statement.py
@@ -22,6 +22,8 @@
 from policyuniverse.statement import Statement
 import unittest
 
+from .helpers import CustomMapping, CustomSequence
+
 # NotPrincipal
 statement01 = dict(
     Effect="Allow",
@@ -327,6 +329,17 @@ statement30 = dict(
     Condition={"StringLike": {"AWS:PrincipalOrgID": "o-*"}},
 )
 
+# Custom Mapping / Sequence types
+statement31 = CustomMapping(
+    dict(
+        Action="s3:GetBucketAcl",
+        Effect="Allow",
+        Principal=CustomMapping({"AWS": "*"}),
+        Resource="arn:aws:s3:::example-bucket",
+        Sid="Public Access",
+    )
+)
+
 
 class StatementTestCase(unittest.TestCase):
     def test_statement_effect(self):
@@ -372,6 +385,10 @@ class StatementTestCase(unittest.TestCase):
         del statement_wo_principal["Principal"]
         statement = Statement(statement_wo_principal)
         self.assertEqual(statement.principals, set([]))
+
+        # Custom types
+        statement = Statement(statement31)
+        self.assertSetEqual(statement.principals, set(["*"]))
 
     def test_statement_conditions(self):
         statement = Statement(statement07)


### PR DESCRIPTION
- [x] Add custom `collections.Mapping` & `collections.Sequence` sub-class test helpers.
- [x] Use abstract base class `collections.Mapping` for type checking in statement principal extraction.
- [x] Add test cases for `Policy` and `Statement` classes to verify the fix. 

Continues work from #94.

Closes #98.