### PR TITLE
Do not ignore ForAny/ForAll set operators when they don't have lists

### DIFF
--- a/policyuniverse/statement.py
+++ b/policyuniverse/statement.py
@@ -207,13 +207,6 @@ class Statement(object):
             ):
                 for key, value in condition[condition_operator].items():
 
-                    # ForAllValues and ForAnyValue must be paired with a list.
-                    # Otherwise, skip over entries.
-                    if not is_array(value) and condition_operator.lower().startswith(
-                        "for"
-                    ):
-                        continue
-
                     if key.lower() in key_mapping:
                         if is_array(value):
                             for v in value:

--- a/policyuniverse/tests/test_statement.py
+++ b/policyuniverse/tests/test_statement.py
@@ -283,7 +283,7 @@ statement26 = dict(
 )
 
 # Testing ForAnyValue/ForAllValues without list
-# Like statement 07, but this one shouldn't work
+# Like statement 07, this should work, even though it's using a set operator
 statement27 = dict(
     Effect="Allow",
     Principal="*",
@@ -297,7 +297,7 @@ statement27 = dict(
 )
 
 # Testing ForAnyValue/ForAllValues without list
-# Like statement 10, but this one shouldn't work
+# Like statement 10, this should work, even though it's using a set operator
 statement28 = dict(
     Effect="Allow",
     Principal="*",
@@ -398,7 +398,10 @@ class StatementTestCase(unittest.TestCase):
         )
 
         statement = Statement(statement27)
-        self.assertEqual(statement.condition_arns, set([]))
+        self.assertEqual(
+            statement.condition_arns,
+            set(["arn:aws:iam::012345678910:role/SomeTestRoleForTesting"]),
+        )
 
         statement = Statement(statement08)
         self.assertEqual(
@@ -417,7 +420,9 @@ class StatementTestCase(unittest.TestCase):
         )
 
         statement = Statement(statement28)
-        self.assertEqual(statement.condition_accounts, set([]))
+        self.assertEqual(
+            statement.condition_accounts, set(["012345678910", "123456789123"])
+        )
 
         statement = Statement(statement11)
         self.assertEqual(
@@ -486,11 +491,11 @@ class StatementTestCase(unittest.TestCase):
         # 22 is a likely malformed user ARN, but lacking an account number
         self.assertTrue(Statement(statement22).is_internet_accessible())
 
-        # 27 is like 07, but with the mistake of not providing a list for ForAny/ForAll
-        self.assertTrue(Statement(statement27).is_internet_accessible())
+        # 27 is like 07, but does not provide a list for ForAny/ForAll
+        self.assertFalse(Statement(statement27).is_internet_accessible())
 
-        # 28 is like 10, but with the mistake of not providing a list for ForAny/ForAll
-        self.assertTrue(Statement(statement28).is_internet_accessible())
+        # 28 is like 10, but does not provide a list for ForAny/ForAll
+        self.assertFalse(Statement(statement28).is_internet_accessible())
 
         # AWS:PrincipalOrgID
         self.assertFalse(Statement(statement29).is_internet_accessible())


### PR DESCRIPTION
I noticed what I think is a bug in the _condition_entries() function within statement.py (lines 210-215), which states:

```
# ForAllValues and ForAnyValue must be paired with a list.
# Otherwise, skip over entries.
```

...before tossing out any ForAny/ForAll values which aren't a list. I'm not sure why this is here - it seems it was true previously, since someone made a note of it and tests to confirm - but when testing it seems that ForAny/ForAll operators which correspond to a single value (not in a list) are now interpreted correctly. For example, testing SNS subscriptions to a queue with the following access policy configured:

```
{
  "Version": "2012-10-17",
  "Id": "default",
  "Statement": [
    {
      "Sid": "default",
      "Effect": "Allow",
      "Principal": {
        "AWS": "*"
      },
      "Action": "SQS:*",
      "Resource": "arn:aws:sqs:us-west-2:<account_id_1>:policyuniverse-test-queue",
      "Condition": {
        "ForAnyValue:ArnEquals": {
          "aws:SourceArn": "arn:aws:sns:us-west-2:<account_id_2>:policyuniverse-test-topic"
        }
      }
    }
  ]
}
```

Attempting to access this SQS queue resulted in:
| Source | Outcome |
|---|---|
| Any SNS topic in Account 1 | **Denied** |
| policyuniverse-test-topic in Account 2 | Permitted |
| Any other SNS topic in Account 2 | **Denied** |

Further, if you try to put the following current-verion-of-Policy-Universe-approved Access Policy as your SQS Queue's Access Policy, it's actually simplified by AWS to the above, current-verion-of-Policy-Universe-not-approved policy:

```
{
  "Version": "2012-10-17",
  "Id": "default",
  "Statement": [
    {
      "Sid": "default",
      "Effect": "Allow",
      "Principal": {
        "AWS": "*"
      },
      "Action": "SQS:*",
      "Resource": "arn:aws:sqs:us-west-2:<account_id_1>:policyuniverse-test-queue",
      "Condition": {
        "ForAnyValue:ArnEquals": {
          "aws:SourceArn": [
            "arn:aws:sns:us-west-2:<account_id_2>:policyuniverse-test-topic"
          ]
        }
      }
    }
  ]
}
```

This PR removes the logic currently don't believe is correct, and updates the tests to reflect that change (specifically, statements 27 and 28 of test-statement.py). I admit this is not 100% exhaustively tested, though I wasn't able to find other documentation which states that lists are required for set operators in Conditions statements. If there's anything else I can test, please let me know. Cheers!