### PR TITLE
Add support for aws:PrincipalARN in statement conditions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -46,6 +46,7 @@ jobs:
     - name: Upload coverage data under py37
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: success() && matrix.python-version == '3.7'
       run: |
         coveralls

--- a/policyuniverse/statement.py
+++ b/policyuniverse/statement.py
@@ -172,6 +172,7 @@ class Statement(object):
 
         key_mapping = {
             "aws:sourcearn": "arn",
+            "aws:principalarn": "arn",
             "aws:sourceowner": "account",
             "aws:sourceaccount": "account",
             "aws:principalorgid": "org-id",

--- a/policyuniverse/tests/test_statement.py
+++ b/policyuniverse/tests/test_statement.py
@@ -340,6 +340,15 @@ statement31 = CustomMapping(
     )
 )
 
+# aws:PrincipalARN in conditions
+statement32 = dict(
+    Effect="Allow",
+    Principal="*",
+    Action=["s3:*"],
+    Resource="*",
+    Condition={"ArnEquals": {"AWS:PrincipalARN": "arn:aws:iam::012345678910:role/SomePrincipalRole"}},
+)
+
 
 class StatementTestCase(unittest.TestCase):
     def test_statement_effect(self):
@@ -457,6 +466,12 @@ class StatementTestCase(unittest.TestCase):
         statement = Statement(statement30)
         self.assertEqual(statement.condition_orgids, set(["o-*"]))
 
+        statement = Statement(statement32)
+        self.assertEqual(
+            statement.condition_arns,
+            set(["arn:aws:iam::012345678910:role/SomePrincipalRole"]),
+        )
+
     def test_statement_internet_accessible(self):
         self.assertTrue(Statement(statement14).is_internet_accessible())
         self.assertTrue(Statement(statement15).is_internet_accessible())
@@ -502,3 +517,6 @@ class StatementTestCase(unittest.TestCase):
 
         # AWS:PrincipalOrgID Wildcard
         self.assertTrue(Statement(statement30).is_internet_accessible())
+
+        # AWS:PrincipalARN
+        self.assertFalse(Statement(statement32).is_internet_accessible())

--- a/policyuniverse/tests/test_statement.py
+++ b/policyuniverse/tests/test_statement.py
@@ -346,7 +346,11 @@ statement32 = dict(
     Principal="*",
     Action=["s3:*"],
     Resource="*",
-    Condition={"ArnEquals": {"AWS:PrincipalARN": "arn:aws:iam::012345678910:role/SomePrincipalRole"}},
+    Condition={
+        "ArnEquals": {
+            "AWS:PrincipalARN": "arn:aws:iam::012345678910:role/SomePrincipalRole"
+        }
+    },
 )
 
 


### PR DESCRIPTION
Addresses #102, but does not differentiate PrincipalARNs internally from ARNs. This is different from the solution I posted in that issue, as I noted that `KMS:CallerAccount`, `AWS:SourceAccount`, and `AWS:SourceOwner` use the same internal representation, and are not returned separately by the `condition_accounts` property.

In addition, a test case has been added to verify that the PrincipalARN is identified correctly, and that statements which use an appropriately-restrictive PrincipalARN are not mislabeled as publicly accessible.