### PR TITLE
Skip coverage upload on PR from fork

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -47,6 +47,6 @@ jobs:
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: success() && matrix.python-version == '3.7'
+      if: success() && matrix.python-version == '3.7' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
       run: |
-        coveralls -v --service=github-actions
+        coveralls --service=github

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -49,4 +49,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: success() && matrix.python-version == '3.7'
       run: |
-        coveralls
+        coveralls -v --service=github-actions

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Upload coverage data under py37
       env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: success() && matrix.python-version == '3.7'
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Upload coverage data under py37
       env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: success() && matrix.python-version == '3.7' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
       run: |


### PR DESCRIPTION
Uploading coverage reports fails from a fork due to the unavailability of secrets. This PR adds more conditions to the coverage upload step so it gets skipped on PRs from forks.