### PR TITLE
Add NodeJS setup step to Updater action

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,18 +31,10 @@ jobs:
         pre-commit run -a
     - name: Test with pytest/coverage
       run: |
-        pip install pytest coveralls
-        coverage run -a -m py.test policyuniverse/tests/test_expander_minimizer.py
-        coverage run -a -m py.test policyuniverse/tests/test_arn.py
-        coverage run -a -m py.test policyuniverse/tests/test_statement.py
-        coverage run -a -m py.test policyuniverse/tests/test_policy.py
-        coverage run -a -m py.test updater/test_service.py
-        coverage run -a -m py.test updater/test_service_action.py
-
-    - name: Upload coverage data under py37
+        pip install pytest pytest-cov coveralls==2.2.0
+        pytest --cov
+    - name: Upload coverage data to coveralls.io
+      if: success() && matrix.python-version == '3.7'
+      run: coveralls
       env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: success() && matrix.python-version == '3.7' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
-      run: |
-        coveralls --service=github

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,10 @@
 name: Python package
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -16,6 +16,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+      - name: Set up NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
       - name: Download phantomjs
         run: |
           pwd &&\

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -58,7 +58,7 @@ jobs:
           rm phantomjs-2.1.1-linux-x86_64.tar.bz2
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Updating PolicyUniverse SDFs

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -67,8 +67,12 @@ jobs:
           title: 'Updating PolicyUniverse Data.json'
           body: ${{ steps.runupdater.outputs.updatersummary }}
           labels: data-update, automated pr
-          assignees: scriptsrc
-          reviewers: scriptsrc
+          assignees: |
+            scriptsrc
+            patricksanders
+          reviewers: |
+            scriptsrc
+            patricksanders
           team-reviewers: owners, maintainers
           draft: false
           branch: auto_data_update

--- a/updater/updater.py
+++ b/updater/updater.py
@@ -229,6 +229,7 @@ def main():
 
     with open("output_formatted.json", "w") as outfile:
         json.dump(service_data, outfile, indent=2, sort_keys=True)
+        outfile.write("\n")
 
     # print(json.dumps(service_data, indent=2, sort_keys=True))
 


### PR DESCRIPTION
This PR fixes the automatic updater action (most of the time, at least) by explicitly installing the most recent LTS version of NodeJS. I also fixed the coverage upload failures for PRs.