### PR TITLE
Adds PrincipalOrgPath support via new organization.py

### DIFF
--- a/policyuniverse/organization.py
+++ b/policyuniverse/organization.py
@@ -1,0 +1,81 @@
+#     Copyright 2021 Amazon.com, Inc.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: policyuniverse.organization
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor:: Chris Partridge <chris@partridge.tech> @_tweedge
+
+"""
+from policyuniverse import logger
+
+
+class Organization(object):
+    organization = None
+    root = None
+    ou_path = []
+    valid_for_child_ous = False
+    valid_for_parent_ou = False
+    valid_for_all_ous = True
+    error = False
+
+    def __init__(self, input):
+        components_list = input.split("/")
+
+        for component_index in range(0, len(components_list)):
+            component = components_list[component_index]
+
+            if component_index == 0:
+                if component.startswith("o-") or component == "*":
+                    self.organization = component
+                else:
+                    self.error = True
+                    logger.warning(
+                        "Organization Org ID parse error [{}].".format(input)
+                    )
+                    return
+
+            elif component_index == 1:
+                if component.startswith("r-") or component == "*":
+                    self.root = component
+                else:
+                    self.error = True
+                    logger.warning("Organization root parse error [{}].".format(input))
+                    return
+
+            else:
+                if self.valid_for_parent_ou or self.valid_for_child_ous:
+                    self.error = True
+                    logger.warning("Organization OU validity error [{}].".format(input))
+                    return
+
+                if not component:
+                    self.valid_for_parent_ou = True
+                elif component == "*":
+                    self.valid_for_child_ous = True
+                    self.valid_for_parent_ou = True
+                elif component == "ou-*":
+                    self.valid_for_child_ous = True
+                else:
+                    self.valid_for_all_ous = False
+
+                    if component.startswith("ou-"):
+                        self.ou_path.append(component)
+                    else:
+                        self.error = True
+                        logger.warning(
+                            "Organization OU parse error [{}].".format(input)
+                        )
+                        return

--- a/policyuniverse/organization.py
+++ b/policyuniverse/organization.py
@@ -38,44 +38,47 @@ class Organization(object):
             component = components_list[component_index]
 
             if component_index == 0:
-                if component.startswith("o-") or component == "*":
-                    self.organization = component
-                else:
-                    self.error = True
-                    logger.warning(
-                        "Organization Org ID parse error [{}].".format(input)
-                    )
-                    return
-
+                self._parse_organization(component)
             elif component_index == 1:
-                if component.startswith("r-") or component == "*":
-                    self.root = component
-                else:
-                    self.error = True
-                    logger.warning("Organization root parse error [{}].".format(input))
-                    return
-
+                self._parse_root(component)
             else:
-                if self.valid_for_parent_ou or self.valid_for_child_ous:
-                    self.error = True
-                    logger.warning("Organization OU validity error [{}].".format(input))
-                    return
+                self._parse_ou_path(component)
 
-                if not component:
-                    self.valid_for_parent_ou = True
-                elif component == "*":
-                    self.valid_for_child_ous = True
-                    self.valid_for_parent_ou = True
-                elif component == "ou-*":
-                    self.valid_for_child_ous = True
-                else:
-                    self.valid_for_all_ous = False
+            if self.error:
+                return
 
-                    if component.startswith("ou-"):
-                        self.ou_path.append(component)
-                    else:
-                        self.error = True
-                        logger.warning(
-                            "Organization OU parse error [{}].".format(input)
-                        )
-                        return
+    def _parse_organization(self, orgid):
+        if orgid.startswith("o-") or orgid == "*":
+            self.organization = orgid
+        else:
+            self.error = True
+            logger.warning("Organization Org ID parse error [{}].".format(input))
+
+    def _parse_root(self, root):
+        if root.startswith("r-") or root == "*":
+            self.root = root
+        else:
+            self.error = True
+            logger.warning("Organization root parse error [{}].".format(input))
+
+    def _parse_ou_path(self, ou):
+        if self.valid_for_parent_ou or self.valid_for_child_ous:
+            self.error = True
+            logger.warning("Organization OU validity error [{}].".format(input))
+            return
+
+        if not ou:
+            self.valid_for_parent_ou = True
+        elif ou == "*":
+            self.valid_for_child_ous = True
+            self.valid_for_parent_ou = True
+        elif ou == "ou-*":
+            self.valid_for_child_ous = True
+        else:
+            self.valid_for_all_ous = False
+
+            if ou.startswith("ou-"):
+                self.ou_path.append(ou)
+            else:
+                self.error = True
+                logger.warning("Organization OU parse error [{}].".format(input))

--- a/policyuniverse/tests/test_organization.py
+++ b/policyuniverse/tests/test_organization.py
@@ -1,0 +1,147 @@
+#     Copyright 2021 Amazon.com, Inc.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: policyuniverse.tests.test_organization
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor:: Chris Partridge <chris@partridge.tech> @_tweedge
+
+"""
+import unittest
+
+from policyuniverse import logger
+from policyuniverse.organization import Organization
+
+
+class OrganizationTestCase(unittest.TestCase):
+    def test_from_org_id(self):
+        # test valid organization IDs
+        valid_org_ids = ["o-a1b2c3d4e5", "o-*", "*"]
+
+        for org_id in valid_org_ids:
+            logger.info("Testing valid organization ID: {}".format(org_id))
+            organization_obj = Organization(org_id)
+
+            self.assertFalse(organization_obj.error)
+            self.assertEqual(org_id, organization_obj.organization)
+
+        # test invalid organization IDs
+        invalid_org_ids = [
+            "o*",
+            "r-*/ou-a1s2d3f4g5",
+            "/o-*",
+            "r-ab12",
+            "ou-22222222",
+        ]
+
+        for org_id in invalid_org_ids:
+            logger.info("Testing invalid organization ID: {}".format(org_id))
+            organization_obj = Organization(org_id)
+
+            self.assertTrue(organization_obj.error)
+
+    def test_from_org_path(self):
+        # test valid organization paths
+        valid_org_paths = [
+            "o-a1b2c3d4e5/*",
+            "o-a1b2c3d4e5/*/ou-ab12-22222222",
+            "o-a1b2c3d4e5/r-*/ou-*",
+            "o-a1b2c3d4e5/r-ab12/ou-ab12-11111111",
+            "o-a1b2c3d4e5/r-ab12/ou-ab12-11111111/ou-ab12-22222222/",
+            "o-a1b2c3d4e5/r-ab12/ou-ab12-11111111/ou-ab12-22222222/*",
+            "o-a1b2c3d4e5/r-ab12/ou-ab12-11111111/ou-ab12-22222222/ou-*",
+            "o-a1b2c3d4e5/r-ab12/ou-ab12-11111111/ou-ab12-22222222/ou-ab12-33333333/ou-*",
+            "*/*",
+            "*/*/*",
+        ]
+
+        for org_path in valid_org_paths:
+            logger.info("Testing valid organization path: {}".format(org_path))
+            organization_obj = Organization(org_path)
+
+            self.assertFalse(organization_obj.error)
+
+        # test invalid organization paths
+        invalid_org_paths = [
+            "dynamodb.amazonaws.com",
+            "arn:aws:kms:region:111122223333:key/my-example-key",
+            "111122223333",
+            "arn:aws:s3:::some-s3-bucket",
+            "arn:aws:iam::aws:policy/AlexaForBusinessDeviceSetup",
+            "o-a1b2c3d4e5/*/*/*/*",
+            "o-a1b2c3d4e5/r-ab12/ou-ab12-11111111/ou-*/ou-*",
+            "o-a1b2c3d4e5/o-a1b2c3d4e5/r-ab12/ou-22222222",
+            "ou-a1b2c3d4e5/r-ab12/ou-22222222",
+            "*/*/*/*",
+            "o-a1b2c3d4e5/r-ab12/ou-ab12-11111111/ou-ab12-22222222/ou-ab12-33333333/o-*",
+            "o-a1b2c3d4e5/r-ab12/ou-ab12-11111111/ou-ab12-22222222/ou-ab12-33333333/r-*",
+        ]
+
+        for org_path in invalid_org_paths:
+            logger.info("Testing invalid organization path: {}".format(org_path))
+            organization_obj = Organization(org_path)
+
+            self.assertTrue(organization_obj.error)
+
+    def test_parent_and_child_validity(self):
+        # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-principalorgpaths
+        # Source of test cases and explanation
+
+        org_path = "o-a1b2c3d4e5/r-ab12/ou-ab12-11111111/ou-ab12-22222222/"
+        logger.info("Testing parent:true/child:false case {}".format(org_path))
+        organization_obj = Organization(org_path)
+        self.assertTrue(organization_obj.valid_for_parent_ou)
+        self.assertFalse(organization_obj.valid_for_child_ous)
+
+        org_path = "o-a1b2c3d4e5/r-ab12/ou-ab12-11111111/ou-ab12-22222222/*"
+        logger.info("Testing parent:true/child:true case {}".format(org_path))
+        organization_obj = Organization(org_path)
+        self.assertTrue(organization_obj.valid_for_parent_ou)
+        self.assertTrue(organization_obj.valid_for_child_ous)
+
+        org_path = "o-a1b2c3d4e5/r-ab12/ou-ab12-11111111/ou-ab12-22222222/ou-*"
+        logger.info("Testing parent:false/child:true case {}".format(org_path))
+        organization_obj = Organization(org_path)
+        self.assertFalse(organization_obj.valid_for_parent_ou)
+        self.assertTrue(organization_obj.valid_for_child_ous)
+
+        # show false/false as there is neither parent nor child
+        org_path = "o-a1b2c3d4e5/*"
+        logger.info("Testing parent:false/child:false case {}".format(org_path))
+        organization_obj = Organization(org_path)
+        self.assertFalse(organization_obj.valid_for_parent_ou)
+        self.assertFalse(organization_obj.valid_for_child_ous)
+
+    def test_root_toggles_child_validity_in_path(self):
+        # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-principalorgpaths
+        # If an orgpath is given with a root of *, any OU regardless of parent
+        # can access the resource, so long as it is in the organization.
+        # The same can be said of Organizations, from my understanding.
+        # However, once an OU is given, OU-based restrictions apply.
+
+        org_path = "o-a1b2c3d4e5"
+        logger.info("Testing path without root: {}".format(org_path))
+        organization_obj = Organization(org_path)
+        self.assertTrue(organization_obj.valid_for_all_ous)
+
+        org_path = "o-a1b2c3d4e5/*"
+        logger.info("Testing path with root *: {}".format(org_path))
+        organization_obj = Organization(org_path)
+        self.assertTrue(organization_obj.valid_for_all_ous)
+
+        org_path = "o-a1b2c3d4e5/*/ou-ab12-22222222"
+        logger.info("Testing path with root * and trailing path: {}".format(org_path))
+        organization_obj = Organization(org_path)
+        self.assertFalse(organization_obj.valid_for_all_ous)

--- a/policyuniverse/tests/test_policy.py
+++ b/policyuniverse/tests/test_policy.py
@@ -185,7 +185,7 @@ class PolicyTestCase(unittest.TestCase):
 
         self.assertEqual(
             Policy(policy06).condition_entries,
-            set([ConditionTuple(category="org-id", value="o-xxxxxxxxxx")]),
+            set([ConditionTuple(category="organization", value="o-xxxxxxxxxx")]),
         )
 
     def test_whos_allowed(self):


### PR DESCRIPTION
Resolves #106 

This is a larger PR and might take some reviewing to grok, but I'll include the highlights.

This PR adds:
* policyuniverse/organization.py
* policyuniverse/tests/test_organization.py

These parse and dissect Organization-related content, so far it supports taking in Organization IDs (from `aws:PrincipalOrgID` conditions) and Organization Paths (from `aws:PrincipalOrgPaths` conditions), storing them in a new Organization() object which is similar to how Policy Universe handles ARNs.

The core reference material for the implemented logic is from reading:
* https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-principalorgpaths
* https://aws.amazon.com/blogs/security/iam-share-aws-resources-groups-aws-accounts-aws-organizations/

You'll notice that there is some internal logic surrounding parent and child OUs, which is not used or surfaced currently. This was something I figured I might as well implement, since I needed to ensure that I had a good handle on OrgPath validity and was going to need to implement end-of-OrgPath checks anyway (e.g. an OrgPath probably should not end in `ou-*/ou-*` from my understanding). The logic for whether or not the path applies to parents or children was only slightly more complex - as it adds some hefty logic but allows me to treat all possible-OU-fields the same way - and should simplify works down the line.

This PR also adds a new condition to Statement: condition_orgpaths() which returns full Organizations Paths and IDs, whichever was input. The existing condition_orgids() has been retrofitted to return *only* organization IDs, both for simplicity and for backwards compatibility with any software that expects only organization IDs out of condition_orgids.

And of course, tests have been updated to maintain coverage of normal and edge cases.

I welcome all feedback as usual. :)