### PR TITLE
Fix: Handle edge case in userid internet accessibility check

### DIFF
--- a/policyuniverse/statement.py
+++ b/policyuniverse/statement.py
@@ -322,7 +322,8 @@ class Statement(object):
     def _userid_internet_accessible(self, userid):
         # Trailing wildcards are okay for userids:
         # AROAIIIIIIIIIIIIIIIII:*
-        if userid.index("*") == len(userid) - 1:
+        if userid.find("*") == len(userid) - 1:
+            # note: this will also return False for a zero-length userid
             return False
         return True
 

--- a/policyuniverse/tests/test_statement.py
+++ b/policyuniverse/tests/test_statement.py
@@ -396,6 +396,15 @@ statement35 = dict(
     },
 )
 
+# AWS:userid with no *
+statement36 = dict(
+    Effect="Allow",
+    Principal="*",
+    Action=["rds:*"],
+    Resource="*",
+    Condition={"StringLike": {"AWS:userid": "AROAI1111111111111111:"}},
+)
+
 
 class StatementTestCase(unittest.TestCase):
     def test_statement_effect(self):
@@ -596,3 +605,6 @@ class StatementTestCase(unittest.TestCase):
 
         # AWS:PrincipalOrgPath Wildcard
         self.assertTrue(Statement(statement35).is_internet_accessible())
+
+        # AWS:userid with no *
+        self.assertTrue(Statement(statement36).is_internet_accessible())


### PR DESCRIPTION
This PR switches the userid check to use `find()` instead of `index()`, the latter of which raises a `ValueError` if the substring is not found.

One notable behavior is that a zero-length string as an input to `_userid_internet_accessible()` returns `False`. The only way to get here would be to analyze an invalid policy, so I don't see much value in handling this edge case more explicitly.

Fixes #146 