### PR TITLE
Drop support for Python 3.6, update pre-commit revs to fix build

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,7 +13,11 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
     python: python3
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1  # Use the ref you want to point at
+    rev: v4.2.0  # Use the ref you want to point at
     hooks:
     -   id: trailing-whitespace
     -   id: check-ast
@@ -12,7 +12,7 @@ repos:
         args: ["--autofix"]
 
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.5.7
+    rev: v1.6.0
     hooks:
         -   id: autopep8
 
@@ -23,12 +23,12 @@ repos:
         args: ["--exclude", "venv/,.tox/,.eggs/"]
 
 -   repo: https://github.com/pre-commit/mirrors-isort
-    rev: 'v5.8.0'
+    rev: 'v5.10.1'
     hooks:
       - id: isort
         args: ["--profile", "black"]
 
 -   repo: https://github.com/ambv/black
-    rev: 21.5b1
+    rev: 22.3.0
     hooks:
     - id: black

--- a/policyuniverse/tests/test_action_categories.py
+++ b/policyuniverse/tests/test_action_categories.py
@@ -68,6 +68,7 @@ class ActionGroupTestCase(unittest.TestCase):
         for action in read_only_actions:
             # read actions shouldn't start with "Put" or "Create" unless they are miscategorized.
             if action in {
+                "cloud9:createenvironmenttoken",
                 "codeguru-reviewer:createconnectiontoken",
                 "ssm:putconfigurepackageresult",
                 "kinesisanalytics:createapplicationpresignedurl",
@@ -96,6 +97,8 @@ class ActionGroupTestCase(unittest.TestCase):
                 "cloudshell:getfiledownloadurls",
                 "cloudshell:getfileuploadurls",
                 "bugbust:getjoineventstatus",
+                "elasticmapreduce:getpersistentappuipresignedurl",
+                "elasticmapreduce:getonclusterappuipresignedurl",
             }:  # miscategorized AWS actions
                 continue
             self.assertFalse(":get" in action, action)

--- a/policyuniverse/tests/test_action_categories.py
+++ b/policyuniverse/tests/test_action_categories.py
@@ -35,7 +35,7 @@ class ActionGroupTestCase(unittest.TestCase):
         self.assertIn("ec2", groups.keys())
         self.assertIn("iam", groups.keys())
         self.assertEqual(groups["ec2"], {"Write"})
-        self.assertEqual(groups["iam"], {u"Permissions", "List"})
+        self.assertEqual(groups["iam"], {"Permissions", "List"})
 
     def test_actions_for_category(self):
         from policyuniverse.action_categories import actions_for_category

--- a/policyuniverse/tests/test_expander_minimizer.py
+++ b/policyuniverse/tests/test_expander_minimizer.py
@@ -126,6 +126,7 @@ AUTOSCALING_PERMISSIONS = sorted(
         "autoscaling:enterstandby",
         "autoscaling:executepolicy",
         "autoscaling:exitstandby",
+        "autoscaling:getpredictivescalingforecast",
         "autoscaling:putlifecyclehook",
         "autoscaling:putnotificationconfiguration",
         "autoscaling:putscalingpolicy",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ dev_require = ["pre-commit", "black"]
 
 setup(
     name="policyuniverse",
-    version="1.4.0.20220414",
+    version="1.5.0.20220414",
     description="Parse and Process AWS IAM Policies, Statements, ARNs, and wildcards.",
     long_description=open(os.path.join(ROOT, "README.md")).read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     ],
     packages=["policyuniverse"],
     package_data={"policyuniverse": ["data.json"]},
+    python_requires='>=3.7',
     include_package_data=True,
     zip_safe=False,
     classifiers=["License :: OSI Approved :: Apache Software License"],

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     packages=["policyuniverse"],
     package_data={"policyuniverse": ["data.json"]},
-    python_requires='>=3.7',
+    python_requires=">=3.7",
     include_package_data=True,
     zip_safe=False,
     classifiers=["License :: OSI Approved :: Apache Software License"],


### PR DESCRIPTION
Python 3.6 hit [EOL in December 2021](https://endoflife.date/python). Something was broken in the Python 3.6 build, so the easiest solution was to remove it.

This also makes some other changes to unbreak the build process.