### PR TITLE
feat: consider Statement Conditions for iam:PassRole as valid in the statement conditions checker

### DIFF
--- a/policyuniverse/statement.py
+++ b/policyuniverse/statement.py
@@ -144,7 +144,7 @@ class Statement(object):
             structure.add(value)
 
     def _condition_entries(self):
-        """Extracts any ARNs, Account Numbers, UserIDs, Usernames, CIDRs, VPCs, and VPC Endpoints from a condition block.
+        """Extracts any ARNs, Account Numbers, UserIDs, Usernames, AWS Services, CIDRs, VPCs, and VPC Endpoints from a condition block.
 
         Ignores any negated condition operators like StringNotLike.
         Ignores weak condition keys like referer, date, etc.
@@ -159,6 +159,7 @@ class Statement(object):
         - A limiting ARN
         - Account Identifier
         - AWS Organization Principal Org ID
+        - AWS Service
         - User ID
         - Source IP / CIDR
         - VPC
@@ -188,6 +189,7 @@ class Statement(object):
             # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_saml.html
             # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html
             "saml:aud": "saml-endpoint",
+            "iam:passedtoservice": "service",
         }
 
         relevant_condition_operators = [
@@ -265,6 +267,10 @@ class Statement(object):
     @property
     def condition_vpces(self):
         return self._condition_field("vpce")
+    
+    @property
+    def condition_services(self):
+        return self._condition_field("service")
 
     def _condition_field(self, field):
         return set(

--- a/policyuniverse/tests/test_statement.py
+++ b/policyuniverse/tests/test_statement.py
@@ -405,6 +405,13 @@ statement36 = dict(
     Condition={"StringLike": {"AWS:userid": "AROAI1111111111111111:"}},
 )
 
+# iam:PassRole with StringEquals condition on iam:PassedToService
+statement37 = dict(
+    Effect="Allow",
+    Action=["iam:PassRole"],
+    Resource="*",
+    Condition={"StringEquals": {"iam:PassedToService": "cloudwatch.amazonaws.com"}},
+)
 
 class StatementTestCase(unittest.TestCase):
     def test_statement_effect(self):
@@ -547,6 +554,9 @@ class StatementTestCase(unittest.TestCase):
             statement.condition_orgpaths,
             set(["o-*/r-ab12/ou-ab12-11111111/ou-ab12-22222222/ou-*"]),
         )
+
+        statement = Statement(statement37)
+        self.assertEqual(statement.condition_services, set(["cloudwatch.amazonaws.com"]))
 
     def test_statement_internet_accessible(self):
         self.assertTrue(Statement(statement14).is_internet_accessible())


### PR DESCRIPTION
As a user, I believe that the conditions_entries property on a Statement should reflect well-formed conditions when the Action is `iam:PassRole`. 

`iam:PassRole` uses a string based condition check. [The example AWS Docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html) instruct us to evaluate the attribute `aws:PassedToService`. 

I didn't see a clean way of `ARN()` ifying the value of aws:PassedToService, though presumably that would be part of a well-formed condition in this scenario. From my understanding, the `aws:` prefixed items that can appear in an IAM evaluation cannot have user-defined values, and as such maybe it's fine that the value of aws:PassedToService is coming through as "service.amazonaws.com" 🤷

I hope that you'll consider this as an extension to the existing conditional evaluations. 

