### PR TITLE
Correct incorrect label action on chime:ValidateE911Address and redshift:DescribeEndpointAuthorization

### DIFF
--- a/policyuniverse/tests/test_action_categories.py
+++ b/policyuniverse/tests/test_action_categories.py
@@ -37,6 +37,16 @@ class ActionGroupTestCase(unittest.TestCase):
         self.assertEqual(groups["ec2"], {"Write"})
         self.assertEqual(groups["iam"], {"Permissions", "List"})
 
+    def test_regression_on_past_errors_chime_ValidateE911Address(self):
+        from policyuniverse.action_categories import categories_for_actions
+
+        actions = [
+            "chime:validatee911address",
+        ]
+        groups = categories_for_actions(actions)
+        self.assertIn("chime", groups.keys())
+        self.assertEqual(groups["chime"], {"Read"})
+
     def test_actions_for_category(self):
         from policyuniverse.action_categories import actions_for_category
 

--- a/policyuniverse/tests/test_action_categories.py
+++ b/policyuniverse/tests/test_action_categories.py
@@ -47,6 +47,16 @@ class ActionGroupTestCase(unittest.TestCase):
         self.assertIn("chime", groups.keys())
         self.assertEqual(groups["chime"], {"Read"})
 
+    def test_regression_on_past_errors_redshift_DescribeEndpointAuthorization(self):
+        from policyuniverse.action_categories import categories_for_actions
+
+        actions = [
+            "redshift:describeendpointauthorization",
+        ]
+        groups = categories_for_actions(actions)
+        self.assertIn("redshift", groups.keys())
+        self.assertEqual(groups["redshift"], {"List"})
+
     def test_actions_for_category(self):
         from policyuniverse.action_categories import actions_for_category
 


### PR DESCRIPTION
Summary: 
* `chime:validate*` is categorized as ["Read", "Write"]. 
* `redshift:DescribeEndpointAuthorization` is categorized as ["Permissions"]

Root cause: 
* `chime:ValidateE911Address` is encoded as "Write" in data.json
* `redshift:DescribeEndpointAuthorization` is encoded as "Permissions" in data.json

<img width="914" alt="Screenshot 2024-06-20 at 10 39 16 AM" src="https://github.com/Netflix-Skunkworks/policyuniverse/assets/1200287/2288bfda-0b5b-40f4-9c40-661ef67cd990">

<img width="916" alt="Screenshot 2024-06-21 at 9 24 43 AM" src="https://github.com/Netflix-Skunkworks/policyuniverse/assets/1200287/fc7b6adc-e6d2-45a6-98d1-7f12a84a71c1">


test case:

```
>>> policy = { "Statement": [{"Action": ["chime:validate*"], "Resource": "*", "Effect": "Allow"}]}
>>> from policyuniverse.policy import Policy
>>> p = Policy(policy)
>>> for k, v in p.action_summary().items():
...     print(k,v)
... 
chime {'Read', 'Write'}
```

I suspect the data.json is not up to date. 